### PR TITLE
Render markdown channels, timestamp and message separately

### DIFF
--- a/src/sdm/ui/ConsoleMessageClient.ts
+++ b/src/sdm/ui/ConsoleMessageClient.ts
@@ -133,10 +133,9 @@ export class ConsoleMessageClient implements MessageClient, SlackMessageClient {
      * @param {string} markdown
      */
     private writeToChannel(channels: string[] | string, markdown: string) {
-        const outputText = withinRenderableSize(markdown) ?
-            marked(` **${channels}** ${this.dateString()} ` + markdown, this.markedOptions) :
-            markdown;
-        return this.sender(chalk.gray("#") + outputText);
+        const outputText = ` ${marked(`**${channels}**`, this.markedOptions).trim()} ${this.dateString()} ${
+            marked(markdown, this.markedOptions).trim()}`;
+        return this.sender(chalk.gray("#") + outputText + "\n");
     }
 
     public dateString() {
@@ -159,16 +158,4 @@ export class ConsoleMessageClient implements MessageClient, SlackMessageClient {
         }) {
     }
 
-}
-
-/**
- * Make a guess whether the `marked` program can render this in markdown in a reasonable amount of time.
- * We have observed that it can take 60s to render a twelve-item list of sufficient interestingness.
- * See: https://github.com/atomist/sdm-local/issues/123
- */
-function withinRenderableSize(markdown: string): boolean {
-    if (!markdown) {
-        return true;
-    }
-    return (markdown.length < 1000) && (markdown.split("\n").length < 12);
 }

--- a/src/sdm/ui/ConsoleMessageClient.ts
+++ b/src/sdm/ui/ConsoleMessageClient.ts
@@ -91,8 +91,18 @@ export class ConsoleMessageClient implements MessageClient, SlackMessageClient {
                     await this.writeToChannel(channel, msg.text);
                 }
                 (msg.attachments || []).forEach(async att => {
+                    let text = "";
+                    if (!!att.author_name) {
+                        text += `__${att.author_name}__\n`;
+                    }
+                    if (!!att.title) {
+                        text += `**${att.title}**\n`;
+                    }
                     if (!!att.text) {
-                        await this.writeToChannel(channel, att.text);
+                        text += att.text;
+                    }
+                    if (!!text) {
+                        await this.writeToChannel(channel, text);
                     }
                     (att.actions || []).forEach(async (action, index) => {
                         await this.renderAction(channel, action, actionKeyFor(msg, index));

--- a/test/cli/ui/ConsoleMessageClient.test.ts
+++ b/test/cli/ui/ConsoleMessageClient.test.ts
@@ -21,11 +21,6 @@ import { ConsoleMessageClient } from "./../../../src/sdm/ui/ConsoleMessageClient
 describe("message formatting", () => {
     it("doesn't freeze on this dangerous string", async () => {
 
-        // This attachment once caused the printing programs to freeze forever.
-        // 3s for 12
-        // 10s for 13
-        // 50s for 14
-        // 16 never returns within our span of patiences
         const suspiciousAttachment: Attachment = {
             author_name: "Commands",
             fallback: "Commands",
@@ -54,5 +49,20 @@ describe("message formatting", () => {
 
         await subject.addressChannels({ text: "I am safe", attachments: [suspiciousAttachment] }, "general");
         assert(output.includes("WhereAmI"), "It's OK if it didn't render it in markdown, but it should display the whole attachment");
+        process.stdout.write(output);
     });
+
+    it("render multi line markdown correct", async () => {
+        const text = `**test some
+bold text**`;
+
+        let output = "";
+        const subject = new ConsoleMessageClient("general", async s => { output = output + s; }, {} as any);
+
+        await subject.addressChannels({ text }, "general");
+        assert(output.includes(`test some
+bold text`));
+        process.stdout.write(output);
+    });
+
 });

--- a/test/cli/ui/ConsoleMessageClient.test.ts
+++ b/test/cli/ui/ConsoleMessageClient.test.ts
@@ -48,8 +48,7 @@ describe("message formatting", () => {
         const subject = new ConsoleMessageClient("general", async s => { output = output + s; }, {} as any);
 
         await subject.addressChannels({ text: "I am safe", attachments: [suspiciousAttachment] }, "general");
-        assert(output.includes("WhereAmI"), "It's OK if it didn't render it in markdown, but it should display the whole attachment");
-        process.stdout.write(output);
+        assert(output.includes("WhereAmI"), "it should display the whole attachment");
     });
 
     it("render multi line markdown correct", async () => {
@@ -62,7 +61,6 @@ bold text**`;
         await subject.addressChannels({ text }, "general");
         assert(output.includes(`test some
 bold text`));
-        process.stdout.write(output);
     });
 
 });


### PR DESCRIPTION
This tiny change made it work. This does not split by line etc. 

fixes #123