### PR TITLE
Use 'warn' log level in embedded SDM

### DIFF
--- a/lib/cli/embedded/embeddedMachine.ts
+++ b/lib/cli/embedded/embeddedMachine.ts
@@ -31,13 +31,13 @@ import {
 } from "@atomist/sdm-core";
 import { ConfigureMachine } from "@atomist/sdm/api/machine/MachineConfigurer";
 import { SoftwareDeliveryMachineConfiguration } from "@atomist/sdm/api/machine/SoftwareDeliveryMachineOptions";
+import * as _ from "lodash";
 import { DefaultWorkspaceId } from "../../common/binding/defaultWorkspaceContextResolver";
 import { configureLocal } from "../../sdm/configuration/configureLocal";
 import { LocalSdmConfig } from "../../sdm/configuration/localSdmConfig";
 import { LocalLifecycle } from "../../sdm/ui/localLifecycle";
 import { AutomationClientInfo } from "../AutomationClientInfo";
 import { fetchMetadataFromAutomationClient } from "../invocation/http/fetchMetadataFromAutomationClient";
-import * as _ from "lodash";
 
 /**
  * Default port on which to start an embedded machine.

--- a/lib/cli/embedded/embeddedMachine.ts
+++ b/lib/cli/embedded/embeddedMachine.ts
@@ -37,6 +37,7 @@ import { LocalSdmConfig } from "../../sdm/configuration/localSdmConfig";
 import { LocalLifecycle } from "../../sdm/ui/localLifecycle";
 import { AutomationClientInfo } from "../AutomationClientInfo";
 import { fetchMetadataFromAutomationClient } from "../invocation/http/fetchMetadataFromAutomationClient";
+import * as _ from "lodash";
 
 /**
  * Default port on which to start an embedded machine.
@@ -135,6 +136,7 @@ export async function startEmbeddedMachine(options: EmbeddedMachineOptions): Pro
     }
     process.env.ATOMIST_MODE = "local";
     const config = await invokePostProcessors(configurationFor(optsToUse)) as LocalSoftwareDeliveryMachineConfiguration;
+    _.set(config, "logging.level", "warn");
 
     const client = automationClient(config);
     await client.run();

--- a/lib/sdm/binding/message/HttpClientMessageClient.ts
+++ b/lib/sdm/binding/message/HttpClientMessageClient.ts
@@ -110,7 +110,7 @@ export class HttpClientMessageClient implements MessageClient, SlackMessageClien
                 // Stop sending messages here. it must have gone away
                 this.dead = true;
             }
-            logger.info("Cannot POST to log service at [%s]: %s", this.url, err.message);
+            logger.debug("Cannot POST to log service at [%s]: %s", this.url, err.message);
         }
     }
 


### PR DESCRIPTION
This is so, so much better
The message of where the SDM was created is already sent, but it was indistinguishable in all the logging output.
now it looks like this:
<img width="1205" alt="screen shot 2018-09-06 at 11 18 07 am" src="https://user-images.githubusercontent.com/1149737/45177056-b306ac00-b1c6-11e8-802c-f6a4f644a789.png">
