### PR TITLE
Improve directory path comparisons

### DIFF
--- a/lib/cli/invocation/git/runOnGitHook.ts
+++ b/lib/cli/invocation/git/runOnGitHook.ts
@@ -58,7 +58,7 @@ const verbose = process.env.ATOMIST_GITHOOK_VERBOSE === "true";
 export async function runOnGitHook(argv: string[],
                                    clientFinder: AutomationClientFinder = defaultAutomationClientFinder(),
 ) {
-    const invocation = argsToGitHookInvocation(argv, DefaultWorkspaceContextResolver);
+    const invocation = await argsToGitHookInvocation(argv, DefaultWorkspaceContextResolver);
     if (isAtomistTemporaryBranch(invocation.branch)) {
         logger.info("Ignoring Atomist temporary branch in '%j': Atomist will eventually surface these changes to let hook react",
             invocation);

--- a/lib/cli/setup/addGitHooks.ts
+++ b/lib/cli/setup/addGitHooks.ts
@@ -44,7 +44,7 @@ export async function addGitHooks(projectBaseDir: string) {
 
 export async function addGitHooksToProject(p: LocalProject) {
     for (const event of Object.values(HookEvent)) {
-        const atomistContent = scriptFragments()[event];
+        const atomistContent = scriptFragments()[event as HookEvent];
         if (!atomistContent) {
             errorMessage("Unable to create git script content for event '%s'", event);
             process.exit(1);
@@ -122,26 +122,21 @@ export async function deatomizeScript(p: LocalProject, scriptPath: string): Prom
 
 /**
  * Indexed templates fragments for use in git hooks
- * @return {{"pre-receive": string}}
+ * @return object whose keys are HookEvents and whose values are the shell script snippet for the hook
  */
-function scriptFragments(): { [key: string]: string } {
+function scriptFragments(): { [key in HookEvent]: string } {
     const bg = (os.platform() === "win32") ? "" : " &";
     return {
-        "post-receive": `
+        [HookEvent.PostReceive]: `
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-read oldrev newrev refname
-atomist git-hook post-receive "$PWD" "$refname" "$newrev"${bg}
+atomist git-hook ${HookEvent.PostReceive}${bg}
 `,
-        "post-commit": `
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook post-commit "$PWD" "$branch" "$sha"${bg}
+        [HookEvent.PostCommit]: `
+atomist git-hook ${HookEvent.PostCommit}${bg}
 `,
-        "post-merge": `
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook post-merge "$PWD" "$branch" "$sha"${bg}
+        [HookEvent.PostMerge]: `
+atomist git-hook ${HookEvent.PostMerge}${bg}
 `,
     };
 }

--- a/lib/common/git/handlePushBasedEventOnRepo.ts
+++ b/lib/common/git/handlePushBasedEventOnRepo.ts
@@ -77,9 +77,7 @@ export async function handlePushBasedEventOnRepo(workspaceId: string,
                                                  opts: LocalSoftwareDeliveryMachineOptions,
                                                  payload: EventOnRepo,
                                                  eventHandlerName: string,
-                                                 pushToPayload: (p: Push) => object = p => ({
-                                                     Push: [p],
-                                                 })) {
+                                                 pushToPayload: (p: Push) => object = p => ({ Push: [p] })) {
 
     // This git hook may be invoked from another git hook. This will cause these values to
     // be incorrect, so we need to delete them to have git work them out again from the directory we're passing via cwd
@@ -93,7 +91,7 @@ export async function handlePushBasedEventOnRepo(workspaceId: string,
 
     if (!isWithin(opts.repositoryOwnerParentDirectory, payload.baseDir)) {
         // I would rather send this to the atomist feed
-        return infoMessage(`SDM: skipping push because it is not inside ${opts.repositoryOwnerParentDirectory}\n`);
+        return infoMessage(`SDM: skipping push because '${payload.baseDir}' is not inside '${opts.repositoryOwnerParentDirectory}'\n`);
     }
 
     const push = await createPush(workspaceId, opts, payload);

--- a/lib/sdm/binding/project/expandedTreeUtils.ts
+++ b/lib/sdm/binding/project/expandedTreeUtils.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import * as os from "os";
 import * as path from "path";
+
 /**
  * Return the directory in our expanded structure for the given directory
  * @param {string} repositoryOwnerParentDirectory
@@ -36,8 +38,34 @@ function trimTrailingSlash(dir: string): string {
     return dir.replace(/[\/\\]$/, "");
 }
 
-export function isWithin(repositoryOwnerParentDirectory: string,
-                         baseDir: string): boolean {
+/**
+ * Transform native win32 path to a cygwin path.  All backslashes in
+ * the path are replaced forward slashes and any leading drive letter
+ * is incorprated into the path as a lowercased first directory of the
+ * path.
+ *
+ * @param dir original path
+ * @return cygwinized path
+ */
+export function cygwinizePath(dir: string): string {
+    return dir.replace(/\\/g, "/").replace(/^([A-Za-z]):/, (f, m) => `/${m.toLocaleLowerCase()}`);
+}
+
+/**
+ * Determine whether baseDir is under repositoryOwnerparentdirectory.
+ * On win32, the comparison is done in a case-insensitive way and also
+ * tries to deal with Cygwin-style paths.
+ *
+ * @param repositoryOwnerParentDirectory parent directory
+ * @param baseDir putative child directory
+ * @return true if baseDir is under repositoryownerparentdirectory
+ */
+export function isWithin(repositoryOwnerParentDirectory: string, baseDir: string): boolean {
+    if (os.platform() === "win32") {
+        const owner = repositoryOwnerParentDirectory.toLocaleLowerCase();
+        const repo = baseDir.toLocaleLowerCase();
+        return repo.startsWith(owner) || cygwinizePath(repo).startsWith(cygwinizePath(owner));
+    }
     return baseDir.startsWith(repositoryOwnerParentDirectory);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,6 +262,123 @@
         "lodash": "^4.17.10"
       }
     },
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "7.0.0-beta.51"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+      "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.51",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.5",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+      "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+      "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.51"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+      "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.51"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "lodash": "^4.17.5"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+      "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.51",
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/helper-function-name": "7.0.0-beta.51",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "debug": "^3.1.0",
+        "globals": "^11.1.0",
+        "invariant": "^2.2.0",
+        "lodash": "^4.17.5"
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+      "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.5",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
     "@cronvel/get-pixels": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@cronvel/get-pixels/-/get-pixels-3.3.1.tgz",
@@ -321,15 +438,6 @@
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
-      }
-    },
-    "@types/commander": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
-      "dev": true,
-      "requires": {
-        "commander": "*"
       }
     },
     "@types/connect": {
@@ -1614,12 +1722,6 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
       "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
     },
-    "commandpost": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/commandpost/-/commandpost-1.3.0.tgz",
-      "integrity": "sha512-T62tyrmYTkaRDbV2z1k2yXTyxk0cFptXYwo1cUbnfHtp7ThLgQ9/90jG1Ym5WLZgFhvOTaHA5VSARWJ9URpLDw==",
-      "dev": true
-    },
     "common-tags": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
@@ -2074,20 +2176,6 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
-      }
-    },
-    "editorconfig": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.0.tgz",
-      "integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
-      "dev": true,
-      "requires": {
-        "@types/commander": "^2.11.0",
-        "@types/semver": "^5.4.0",
-        "commander": "^2.11.0",
-        "lru-cache": "^4.1.1",
-        "semver": "^5.4.1",
-        "sigmund": "^1.0.1"
       }
     },
     "ee-first": {
@@ -3022,6 +3110,12 @@
         }
       }
     },
+    "globals": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+      "dev": true
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -3521,6 +3615,15 @@
       "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
       "dev": true
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -3767,6 +3870,27 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
+      "integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/traverse": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "istanbul-lib-coverage": "^2.0.1",
+        "semver": "^5.5.0"
+      }
+    },
     "iterall": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
@@ -3800,6 +3924,12 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true,
       "optional": true
+    },
+    "jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -3999,6 +4129,15 @@
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "lower-case": {
       "version": "1.1.4",
@@ -7541,6 +7680,1137 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "nyc": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.0.1.tgz",
+      "integrity": "sha512-Op/bjhEF74IMtzMmgYt+ModTeMHoPZzHe4qseUguPBwg5qC6r4rYMBt1L3yRXQIbjUpEqmn24/1xAC/umQGU7w==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "arrify": "^1.0.1",
+        "caching-transform": "^2.0.0",
+        "convert-source-map": "^1.5.1",
+        "debug-log": "^1.0.1",
+        "find-cache-dir": "^2.0.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.2",
+        "istanbul-lib-coverage": "^2.0.1",
+        "istanbul-lib-hook": "^2.0.1",
+        "istanbul-lib-instrument": "^2.3.2",
+        "istanbul-lib-report": "^2.0.1",
+        "istanbul-lib-source-maps": "^2.0.1",
+        "istanbul-reports": "^2.0.0",
+        "make-dir": "^1.3.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.2",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^1.4.2",
+        "test-exclude": "^5.0.0",
+        "uuid": "^3.3.2",
+        "yargs": "11.1.0",
+        "yargs-parser": "^9.0.2"
+      },
+      "dependencies": {
+        "align-text": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2",
+            "longest": "^1.0.1",
+            "repeat-string": "^1.5.2"
+          }
+        },
+        "amdefine": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "append-transform": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "^2.0.0"
+          }
+        },
+        "archy": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true,
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "make-dir": "^1.0.0",
+            "md5-hex": "^2.0.0",
+            "package-hash": "^2.0.0",
+            "write-file-atomic": "^2.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "center-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.3",
+            "lazy-cache": "^1.0.3"
+          }
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "convert-source-map": {
+          "version": "1.5.1",
+          "bundled": true,
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "execa": {
+          "version": "0.7.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "foreground-child": {
+          "version": "1.5.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^4",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "async": "^1.4.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.4.4",
+            "uglify-js": "^2.6"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "amdefine": ">=0.0.4"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true,
+          "dev": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true,
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "builtin-modules": "^1.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "istanbul-lib-hook": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "append-transform": "^1.0.0"
+          }
+        },
+        "istanbul-lib-report": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "istanbul-lib-coverage": "^2.0.1",
+            "make-dir": "^1.3.0",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "istanbul-lib-source-maps": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "istanbul-lib-coverage": "^2.0.1",
+            "make-dir": "^1.3.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "istanbul-reports": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.0.11"
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "lazy-cache": {
+          "version": "1.0.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
+        "longest": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "4.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "md5-hex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "mem": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "merge-source-map": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "source-map": "^0.6.1"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.10",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-hash": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "lodash.flattendeep": "^4.4.0",
+            "md5-hex": "^2.0.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0"
+          }
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "es6-error": "^4.0.1"
+          }
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "right-align": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "align-text": "^0.1.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "spawn-wrap": {
+          "version": "1.4.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "foreground-child": "^1.5.6",
+            "mkdirp": "^0.5.0",
+            "os-homedir": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.2",
+            "which": "^1.3.0"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
+            "require-main-filename": "^1.0.1"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "3.10.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
+                "window-size": "0.1.0"
+              }
+            }
+          }
+        },
+        "uglify-to-browserify": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true,
+          "dev": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          },
+          "dependencies": {
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -8570,12 +9840,6 @@
         }
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -9003,6 +10267,12 @@
         "is-negated-glob": "^1.0.0"
       }
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -9022,6 +10292,12 @@
       "version": "0.5.27",
       "resolved": "https://registry.npmjs.org/tree-kit/-/tree-kit-0.5.27.tgz",
       "integrity": "sha512-0AtAzYDYaKSzeEPK3SI72lg/io5jrBxnT1gIRxEQasJycpQf5iXGh6YAl1kkh9wHmLlNRhDx0oj+GZEQHVe+cw=="
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "triple-beam": {
       "version": "1.3.0",
@@ -9235,16 +10511,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
       "dev": true
-    },
-    "typescript-formatter": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/typescript-formatter/-/typescript-formatter-7.2.2.tgz",
-      "integrity": "sha512-V7vfI9XArVhriOTYHPzMU2WUnm5IMdu9X/CPxs8mIMGxmTBFpDABlbkBka64PZJ9/xgQeRpK8KzzAG4MPzxBDQ==",
-      "dev": true,
-      "requires": {
-        "commandpost": "^1.0.0",
-        "editorconfig": "^0.15.0"
-      }
     },
     "uglify-js": {
       "version": "3.4.9",

--- a/package.json
+++ b/package.json
@@ -8,22 +8,22 @@
     "url": "https://atomist.com/"
   },
   "license": "Apache-2.0",
+  "homepage": "https://github.com/atomist/sdm-local#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/atomist/sdm-local.git"
   },
-  "main": "./index.js",
-  "types": "./index.d.ts",
   "keywords": [
     "atomist",
     "automation",
     "sdm",
     "local"
   ],
-  "homepage": "https://github.com/atomist/sdm-local#readme",
   "bugs": {
     "url": "https://github.com/atomist/sdm-local/issues"
   },
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "dependencies": {
     "@atomist/microgrammar": "1.0.0-M.4",
     "@atomist/slack-messages": "1.0.0",
@@ -83,14 +83,15 @@
     "espower-typescript": "^9.0.0",
     "mocha": "^5.2.0",
     "npm-run-all": "^4.1.3",
+    "nyc": "^13.0.1",
     "power-assert": "^1.6.0",
     "rimraf": "^2.6.2",
+    "source-map-support": "^0.5.9",
     "supervisor": "^0.12.0",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "typedoc": "^0.11.1",
-    "typescript": "^2.9.2",
-    "typescript-formatter": "^7.2.2"
+    "typescript": "^2.9.2"
   },
   "directories": {
     "test": "test"
@@ -106,16 +107,32 @@
     "clean:run": "rimraf *-v8.log profile.txt log",
     "compile": "run-s compile:ts",
     "compile:ts": "tsc --project .",
-    "doc": "typedoc --mode modules --ignoreCompilerErrors --exclude \"**/*.d.ts\" --out doc index.ts lib",
-    "fmt": "tsfmt --replace",
+    "doc": "typedoc --mode modules --excludeExternals --ignoreCompilerErrors --exclude \"**/*.d.ts\" --out doc index.ts lib",
     "lint": "tslint --format verbose --project . --exclude \"node_modules/**\" --exclude \"**/*.d.ts\" \"**/*.ts\"",
     "lint:fix": "npm run lint -- --fix",
-    "test": "mocha --require espower-typescript/guess \"test/**/*est.ts\"",
-    "test:one": "mocha --require espower-typescript/guess \"test/**/${TEST:-*.test.ts}\"",
+    "test": "nyc mocha --require espower-typescript/guess --require source-map-support/register \"test/**/*est.ts\"",
+    "test:one": "mocha --require espower-typescript/guess \"test/**/${TEST:-*est.ts}\"",
     "typedoc": "npm run doc"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=8.1.0",
     "npm": ">=5.0.0"
+  },
+  "nyc": {
+    "include": [
+      "lib/**/*.*"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "exclude": [
+      "lib/typings",
+      "**/*.d.ts"
+    ],
+    "reporter": [
+      "html",
+      "text-summary"
+    ],
+    "all": true
   }
 }

--- a/test/cli/entry/argsToGitHookInvocation.test.ts
+++ b/test/cli/entry/argsToGitHookInvocation.test.ts
@@ -14,8 +14,15 @@
  * limitations under the License.
  */
 
+import * as ac from "@atomist/automation-client";
 import * as assert from "power-assert";
-import { argsToGitHookInvocation } from "../../../lib/cli/entry/argsToGitHookInvocation";
+import * as process from "process";
+import {
+    argsToGitHookInvocation,
+    cleanBaseDir,
+    cleanBranch,
+} from "../../../lib/cli/entry/argsToGitHookInvocation";
+import { HookEvent } from "../../../lib/cli/invocation/git/handleGitHookEvent";
 import { WorkspaceContextResolver } from "../../../lib/common/binding/WorkspaceContextResolver";
 
 describe("argsToGitHookInvocation", () => {
@@ -27,104 +34,248 @@ describe("argsToGitHookInvocation", () => {
         },
     };
 
-    it("should parse atomist-githook command line", () => {
-        const a = ["node", "atomist-githook", "event", "dir/ectory", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "dir/ectory");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+    describe("cleanBaseDir", () => {
+
+        it("should directory path alone", () => {
+            assert(cleanBaseDir("dir/ectory") === "dir/ectory");
+        });
+
+        it("should strip trailing forward slash from directory", () => {
+            assert(cleanBaseDir("/path/to/project/") === "/path/to/project");
+        });
+
+        it("should strip trailing .git from directory", () => {
+            assert(cleanBaseDir("/path/to/project/.git") === "/path/to/project");
+        });
+
+        it("should strip trailing .git/hooks/ from directory", () => {
+            assert(cleanBaseDir("/path/to/project/.git/hooks/") === "/path/to/project");
+        });
+
+        it("should directory alone on win32", () => {
+            assert(cleanBaseDir("dir\\ectory") === "dir\\ectory");
+        });
+
+        it("should strip trailing back slash from directory", () => {
+            assert(cleanBaseDir("C:\\path\\to\\project\\") === "C:\\path\\to\\project");
+        });
+
+        it("should strip trailing .git from directory on win32", () => {
+            assert(cleanBaseDir("C:\\path\\to\\project\\.git") === "C:\\path\\to\\project");
+        });
+
+        it("should strip trailing .git\\hooks\\ from directory", () => {
+            assert(cleanBaseDir("A:\\path\\to\\project\\.git\\hooks\\") === "A:\\path\\to\\project");
+        });
+
     });
 
-    it("should parse 'atomist git-hook' command line", () => {
-        const a = ["node", "atomist", "git-hook", "event", "dir/ectory", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "dir/ectory");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+    describe("cleanBranch", () => {
+
+        it("should strip leave simple branch alone", () => {
+            const b = "branch";
+            assert(cleanBranch(b) === b);
+        });
+
+        it("should strip refs/heads/ from branch", () => {
+            assert(cleanBranch("refs/heads/branch") === "branch");
+        });
+
+        it("should leave refs/heads/ not at beginning alone", () => {
+            const b = "some/other/refs/heads/branch";
+            assert(cleanBranch(b) === b);
+        });
+
     });
 
-    it("should strip trailing forward slash from directory", () => {
-        const a = ["node", "atomist-githook", "event", "/path/to/project/", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "/path/to/project");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+    describe("atomist-githook", () => {
+
+        let repoPath: string;
+        let originalProcessCwd: any;
+        before(() => {
+            originalProcessCwd = Object.getOwnPropertyDescriptor(process, "cwd");
+            Object.defineProperty(process, "cwd", { value: () => repoPath });
+        });
+        after(() => {
+            Object.defineProperty(process, "cwd", originalProcessCwd);
+        });
+
+        it("should parse atomist-githook command line", async () => {
+            repoPath = "/home/stan/atomist/Own/the-repo";
+            const a = ["node", "atomist-githook", HookEvent.PostCommit, repoPath, "branch", "sha"];
+            const i = await argsToGitHookInvocation(a, tcr);
+            assert.strictEqual(i.event, "post-commit");
+            assert.strictEqual(i.baseDir, repoPath);
+            assert.strictEqual(i.branch, "branch");
+            assert.strictEqual(i.sha, "sha");
+            assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+        });
+
+        it("should parse atomist-githook command line on win32", async () => {
+            repoPath = "L:\\Users\\stan\\atomist\\Own\\the-repo";
+            const a = ["node", "atomist-githook", "post-merge", repoPath, "branch", "sha"];
+            const i = await argsToGitHookInvocation(a, tcr);
+            assert.strictEqual(i.event, HookEvent.PostMerge);
+            assert.strictEqual(i.baseDir, repoPath);
+            assert.strictEqual(i.branch, "branch");
+            assert.strictEqual(i.sha, "sha");
+            assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+        });
+
     });
 
-    it("should strip trailing forward slash from 'atomist git-hook' directory", () => {
-        const a = ["node", "atomist", "git-hook", "event", "/path/to/project/", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "/path/to/project");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+    describe("atomist git-hook ARGS", () => {
+
+        let repoPath: string;
+        let originalProcessCwd: any;
+        before(() => {
+            originalProcessCwd = Object.getOwnPropertyDescriptor(process, "cwd");
+            Object.defineProperty(process, "cwd", { value: () => repoPath });
+        });
+        after(() => {
+            Object.defineProperty(process, "cwd", originalProcessCwd);
+        });
+
+        it("should parse git-hook command line", async () => {
+            repoPath = "/home/stan/atomist/Own/the-repo";
+            const a = ["node", "atomist", "git-hook", HookEvent.PostCommit, repoPath, "branch", "sha"];
+            const i = await argsToGitHookInvocation(a, tcr);
+            assert.strictEqual(i.event, "post-commit");
+            assert.strictEqual(i.baseDir, repoPath);
+            assert.strictEqual(i.branch, "branch");
+            assert.strictEqual(i.sha, "sha");
+            assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+        });
+
+        it("should parse git-hook command line on win32", async () => {
+            repoPath = "L:\\Users\\stan\\atomist\\Own\\the-repo";
+            const a = ["node", "atomist", "git-hook", "post-merge", repoPath, "branch", "sha"];
+            const i = await argsToGitHookInvocation(a, tcr);
+            assert.strictEqual(i.event, HookEvent.PostMerge);
+            assert.strictEqual(i.baseDir, repoPath);
+            assert.strictEqual(i.branch, "branch");
+            assert.strictEqual(i.sha, "sha");
+            assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+        });
+
     });
 
-    it("should strip trailing .git from directory", () => {
-        const a = ["node", "atomist-githook", "event", "/path/to/project/.git", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "/path/to/project");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
-    });
+    describe("atomist git-hook", () => {
 
-    it("should strip trailing .git/ from directory", () => {
-        const a = ["node", "atomist", "git-hook", "event", "/path/to/project/.git/", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "/path/to/project");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
-    });
+        const sha = "1234567890abcdef1234567890abcdef12345678";
+        const branch = "feature-branch";
 
-    it("should strip trailing .git/hooks from directory", () => {
-        const a = ["node", "atomist", "git-hook", "event", "/path/to/project/.git/hooks", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "/path/to/project");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
-    });
+        let originalSafeExec: any;
+        before(() => {
+            originalSafeExec = Object.getOwnPropertyDescriptor(ac, "safeExec");
+            Object.defineProperty(ac, "safeExec", {
+                value: (cmd: string, args: string[], opts: any) => {
+                    if (cmd !== "git") {
+                        assert.fail(`Unknown command: ${cmd} ${args.join(" ")}`);
+                        return { stdout: "", stderr: "FAIL" };
+                    }
+                    if (args.length === 3 &&
+                        args[0] === "rev-parse" &&
+                        args[1] === "--abbrev-ref" &&
+                        args[2] === "HEAD") {
+                        return { stdout: `refs/heads/${branch}\n`, stderr: "" };
+                    } else if (args.length === 2 &&
+                        args[0] === "rev-parse" &&
+                        args[1] === "HEAD") {
+                        return { stdout: `${sha}\n`, stderr: "" };
+                    }
+                    assert.fail(`Unknown args: ${cmd} ${args.join(" ")}`);
+                    return { stdout: "", stderr: "FAIL\n" };
+                },
+            });
+        });
+        after(() => {
+            Object.defineProperty(ac, "safeExec", originalSafeExec);
+        });
 
-    it("should strip trailing .git/hooks/ from directory", () => {
-        const a = ["node", "atomist-githook", "event", "/path/to/project/.git/hooks/", "branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "/path/to/project");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
-    });
+        describe("posix", () => {
 
-    it("should strip refs/heads/ from branch", () => {
-        const a = ["node", "atomist-githook", "event", "dir/ectory", "refs/heads/branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "dir/ectory");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
-    });
+            let originalProcessCwd: any;
+            before(() => {
+                originalProcessCwd = Object.getOwnPropertyDescriptor(process, "cwd");
+                Object.defineProperty(process, "cwd", { value: () => "/home/stan/atomist/Own/rep" });
+            });
+            after(() => {
+                Object.defineProperty(process, "cwd", originalProcessCwd);
+            });
 
-    it("should strip refs/heads/ from 'atomist git-hook' branch", () => {
-        const a = ["node", "atomist", "git-hook", "event", "dir/ectory", "refs/heads/branch", "sha"];
-        const i = argsToGitHookInvocation(a, tcr);
-        assert.strictEqual(i.event, "event");
-        assert.strictEqual(i.baseDir, "dir/ectory");
-        assert.strictEqual(i.branch, "branch");
-        assert.strictEqual(i.sha, "sha");
-        assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
+            it("should determine arguments", async () => {
+                const a = ["node", "atomist", "git-hook", HookEvent.PostCommit];
+                const i = await argsToGitHookInvocation(a, tcr);
+                assert(i.event === "post-commit");
+                assert(i.baseDir === "/home/stan/atomist/Own/rep");
+                assert(i.branch === branch);
+                assert(i.sha === sha);
+                assert(i.workspaceId === tcr.workspaceContext.workspaceId);
+            });
+
+        });
+
+        describe("win32", () => {
+
+            let originalProcessCwd: any;
+            before(() => {
+                originalProcessCwd = Object.getOwnPropertyDescriptor(process, "cwd");
+                Object.defineProperty(process, "cwd", { value: () => "C:\\Users\\Stan\\atomist\\Own\\rep\\.git\\" });
+            });
+            after(() => {
+                Object.defineProperty(process, "cwd", originalProcessCwd);
+            });
+
+            it("should determine arguments", async () => {
+                const a = ["node", "atomist", "git-hook", HookEvent.PostMerge];
+                const i = await argsToGitHookInvocation(a, tcr);
+                assert(i.event === "post-merge");
+                assert(i.baseDir === "C:\\Users\\Stan\\atomist\\Own\\rep");
+                assert(i.branch === branch);
+                assert(i.sha === sha);
+                assert(i.workspaceId === tcr.workspaceContext.workspaceId);
+            });
+
+        });
+
+        describe("post-receive", () => {
+
+            let originalProcessCwd: any;
+            let originalProcessStdin: any;
+            before(() => {
+                originalProcessCwd = Object.getOwnPropertyDescriptor(process, "cwd");
+                Object.defineProperty(process, "cwd", { value: () => "C:\\Users\\Stan\\atomist\\Own\\rep\\.git\\" });
+                originalProcessStdin = Object.getOwnPropertyDescriptor(process, "stdin");
+                Object.defineProperty(process, "stdin", {
+                    value: {
+                        on: (event: string, f: any) => {
+                            if (event === "data") {
+                                f(`oldsha ${sha} ${branch}\n`);
+                            } else if (event === "end") {
+                                f();
+                            }
+                        },
+                    },
+                });
+            });
+            after(() => {
+                Object.defineProperty(process, "cwd", originalProcessCwd);
+                Object.defineProperty(process, "stdin", originalProcessStdin);
+            });
+
+            it("should determine arguments from stdin", async () => {
+                const a = ["node", "atomist", "git-hook", HookEvent.PostReceive];
+                const i = await argsToGitHookInvocation(a, tcr);
+                assert(i.event === "post-receive");
+                assert(i.baseDir === "C:\\Users\\Stan\\atomist\\Own\\rep");
+                assert(i.branch === branch);
+                assert(i.sha === sha);
+                assert(i.workspaceId === tcr.workspaceContext.workspaceId);
+            });
+
+        });
+
     });
 
 });

--- a/test/cli/setup/addGitHooks.test.ts
+++ b/test/cli/setup/addGitHooks.test.ts
@@ -362,17 +362,14 @@ echo "Goodbye, World!"
 
         describe("win32", () => {
 
-            // tslint:disable:no-invalid-this
-            before(function() {
-                this.originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
-                Object.defineProperty(os, "platform", {
-                    value: () => "win32",
-                });
+            let originalOsPlatform: any;
+            before(() => {
+                originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
+                Object.defineProperty(os, "platform", { value: () => "win32" });
             });
-            after(function() {
-                Object.defineProperty(os, "platform", this.originalOsPlatform);
+            after(() => {
+                Object.defineProperty(os, "platform", originalOsPlatform);
             });
-            // tslint:enable:no-invalid-this
 
             it("should add hooks to project", async () => {
                 const p = InMemoryProject.of();
@@ -387,9 +384,7 @@ echo "Goodbye, World!"
 
 ######## Atomist start ########
 
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook ${h} "$PWD" "$branch" "$sha"
+atomist git-hook ${h}
 
 ######### Atomist end #########
 `;
@@ -405,8 +400,7 @@ atomist git-hook ${h} "$PWD" "$branch" "$sha"
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-read oldrev newrev refname
-atomist git-hook post-receive "$PWD" "$refname" "$newrev"
+atomist git-hook ${h}
 
 ######### Atomist end #########
 `;
@@ -431,9 +425,7 @@ echo ${h}
 
 ######## Atomist start ########
 
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook ${h} "$PWD" "$branch" "$sha"
+atomist git-hook ${h}
 
 ######### Atomist end #########
 `;
@@ -450,8 +442,7 @@ echo ${h}
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-read oldrev newrev refname
-atomist git-hook post-receive "$PWD" "$refname" "$newrev"
+atomist git-hook ${h}
 
 ######### Atomist end #########
 `;
@@ -463,17 +454,14 @@ atomist git-hook post-receive "$PWD" "$refname" "$newrev"
 
         describe("posix", () => {
 
-            // tslint:disable:no-invalid-this
-            before(function() {
-                this.originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
-                Object.defineProperty(os, "platform", {
-                    value: () => "darwin",
-                });
+            let originalOsPlatform: any;
+            before(() => {
+                originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
+                Object.defineProperty(os, "platform", { value: () => "darwin" });
             });
-            after(function() {
-                Object.defineProperty(os, "platform", this.originalOsPlatform);
+            after(() => {
+                Object.defineProperty(os, "platform", originalOsPlatform);
             });
-            // tslint:enable:no-invalid-this
 
             it("should add hooks to project", async () => {
                 const p = InMemoryProject.of();
@@ -488,9 +476,7 @@ atomist git-hook post-receive "$PWD" "$refname" "$newrev"
 
 ######## Atomist start ########
 
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook ${h} "$PWD" "$branch" "$sha" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;
@@ -506,8 +492,7 @@ atomist git-hook ${h} "$PWD" "$branch" "$sha" &
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-read oldrev newrev refname
-atomist git-hook post-receive "$PWD" "$refname" "$newrev" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;
@@ -532,9 +517,7 @@ echo ${h}
 
 ######## Atomist start ########
 
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook ${h} "$PWD" "$branch" "$sha" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;
@@ -551,8 +534,7 @@ echo ${h}
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-read oldrev newrev refname
-atomist git-hook post-receive "$PWD" "$refname" "$newrev" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;
@@ -611,17 +593,14 @@ atomist git-hook post-receive "$PWD" "$refname" "$newrev" &
 
     describe("git hooks round trip", () => {
 
-        // tslint:disable:no-invalid-this
-        before(function() {
-            this.originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
-            Object.defineProperty(os, "platform", {
-                value: () => "freebsd",
-            });
+        let originalOsPlatform: any;
+        before(() => {
+            originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
+            Object.defineProperty(os, "platform", { value: () => "freebsd" });
         });
-        after(function() {
-            Object.defineProperty(os, "platform", this.originalOsPlatform);
+        after(() => {
+            Object.defineProperty(os, "platform", originalOsPlatform);
         });
-        // tslint:enable:no-invalid-this
 
         it("should add and remove project hooks", async () => {
             const p = InMemoryProject.of();
@@ -636,9 +615,7 @@ atomist git-hook post-receive "$PWD" "$refname" "$newrev" &
 
 ######## Atomist start ########
 
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook ${h} "$PWD" "$branch" "$sha" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;
@@ -654,8 +631,7 @@ atomist git-hook ${h} "$PWD" "$branch" "$sha" &
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-read oldrev newrev refname
-atomist git-hook post-receive "$PWD" "$refname" "$newrev" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;
@@ -685,9 +661,7 @@ echo some non-Atomist-y ${h}
 
 ######## Atomist start ########
 
-sha=\`git rev-parse HEAD\`
-branch=\`git rev-parse --abbrev-ref HEAD\`
-atomist git-hook ${h} "$PWD" "$branch" "$sha" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;
@@ -704,8 +678,7 @@ echo some non-Atomist-y ${h}
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-read oldrev newrev refname
-atomist git-hook post-receive "$PWD" "$refname" "$newrev" &
+atomist git-hook ${h} &
 
 ######### Atomist end #########
 `;

--- a/test/sdm/binding/project/expandedTreeUtils.test.ts
+++ b/test/sdm/binding/project/expandedTreeUtils.test.ts
@@ -14,14 +14,92 @@
  * limitations under the License.
  */
 
+import * as os from "os";
 import * as path from "path";
 import * as assert from "power-assert";
 import {
+    cygwinizePath,
+    isWithin,
     parseOwnerAndRepo,
     withinExpandedTree,
-} from "../../lib/sdm/binding/project/expandedTreeUtils";
+} from "../../../../lib/sdm/binding/project/expandedTreeUtils";
 
 describe("expandedTreeUtils", () => {
+
+    describe("cygwinizePath", () => {
+
+        it("should convert an absolute windows path", () => {
+            assert(cygwinizePath("C:\\Program Files\\Java\\jdk1.8.11_131") === "/c/Program Files/Java/jdk1.8.11_131");
+        });
+
+        it("should convert a relative windows path", () => {
+            assert(cygwinizePath("Sam\\Cooke\\change") === "Sam/Cooke/change");
+        });
+
+        it("should leave a cygwin path alone", () => {
+            const p = "/c/Program Files/Java/jdk1.8.11_131";
+            assert(cygwinizePath(p) === p);
+        });
+
+    });
+
+    describe("isWithin", () => {
+
+        describe("posix", () => {
+
+            let originalOsPlatform: any;
+            before(() => {
+                originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
+                Object.defineProperty(os, "platform", { value: () => "openbsd" });
+            });
+            after(() => {
+                Object.defineProperty(os, "platform", originalOsPlatform);
+            });
+
+            it("should detect a subdirectory", () => {
+                assert(isWithin("/path/to/owner", "/path/to/owner/repo"));
+            });
+
+            it("should reject a non-subdirectory", () => {
+                assert(!isWithin("/path/to/owner", "/other/to/owner/repo"));
+            });
+
+        });
+
+        describe("win32", () => {
+
+            let originalOsPlatform: any;
+            before(() => {
+                originalOsPlatform = Object.getOwnPropertyDescriptor(os, "platform");
+                Object.defineProperty(os, "platform", { value: () => "win32" });
+            });
+            after(() => {
+                Object.defineProperty(os, "platform", originalOsPlatform);
+            });
+
+            it("should detect a subdirectory", () => {
+                assert(isWithin("C:\\path\\to\\owner", "C:\\path\\to\\owner\\repo"));
+            });
+
+            it("should reject a non-subdirectory", () => {
+                assert(!isWithin("C:\\path\\to\\owner", "C:\\other\\to\\owner\\repo"));
+            });
+
+            it("should detect a subdirectory ignoring case", () => {
+                assert(isWithin("C:\\Path\\to\\Owner", "C:\\path\\to\\owner\\repo"));
+            });
+
+            it("should detect crazy win32 git bash path", () => {
+                assert(isWithin("C:\\Path\\to\\Owner", "/c/Path/to/Owner/repo"));
+            });
+
+            it("should reject a cygwin non-subdirectory", () => {
+                assert(!isWithin("C:\\path\\to\\owner", "/c/other/to/owner/epo"));
+            });
+
+        });
+
+    });
 
     describe("parseOwnerAndRepo", () => {
 
@@ -75,7 +153,7 @@ describe("expandedTreeUtils", () => {
             const dirs = [path.join("a", "b"), path.join("c", "d"), path.join("a-thing", "other-thing")];
             dirs.forEach(d => {
                 const dir = path.join(base, "" + d);
-                assert(withinExpandedTree(base, dir), `${dir} is not within ${base}`);
+                assert(withinExpandedTree(base, dir), `${dir} should be within ${base}`);
             });
         });
 
@@ -84,7 +162,7 @@ describe("expandedTreeUtils", () => {
             const dirs = ["ab", "c", "d", "e", "a-thi", "", "ng", "other-thing"];
             dirs.forEach(d => {
                 const dir = path.join(base, "" + d);
-                assert(!withinExpandedTree(base, dir), `${dir} is not within ${base}`);
+                assert(!withinExpandedTree(base, dir), `${dir} should not be within ${base}`);
             });
         });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,40 +1,33 @@
 {
-    "compilerOptions": {
-        "newLine": "LF",
-        "target": "ES6",
-        "module": "CommonJS",
-        "moduleResolution": "Node",
-        "jsx": "React",
-        "declaration": true,
-        "sourceMap": true,
-        "rootDir": ".",
-        "lib": [
-            "DOM",
-            "ES2017",
-            "DOM.Iterable",
-            "ScriptHost",
-            "esnext.asynciterable"
-        ],
-        "strict": true,
-        "strictNullChecks": false,
-        "forceConsistentCasingInFileNames": true,
-        "noImplicitReturns": true,
-        "noUnusedLocals": true,
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true
-    },
-    "exclude": [
-        "assets",
-        "build",
-        "doc",
-        "legal",
-        "log",
-        "node_modules",
-        ".#*"
+  "compilerOptions": {
+    "newLine": "LF",
+    "target": "ES2016",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "jsx": "React",
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": ".",
+    "lib": [
+      "DOM",
+      "ES2017",
+      "DOM.Iterable",
+      "ScriptHost",
+      "esnext.asynciterable"
     ],
-    "compileOnSave": true,
-    "buildOnSave": false,
-    "atom": {
-        "rewriteTsconfig": false
-    }
+    "strict": true,
+    "strictNullChecks": false,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": ["index.ts", "bin/*.ts", "lib/**/*.ts", "test/**/*.ts"],
+  "exclude": [".#*"],
+  "compileOnSave": true,
+  "buildOnSave": false,
+  "atom": {
+    "rewriteTsconfig": false
+  }
 }


### PR DESCRIPTION
The "belt & suspenders" commit.  Properly deal with path separators
when determining project base directory when invoking Git hooks.  When
Git hooks were invoked, the `$PWD` was a Cygwin-style path, e.g.,
C:\Some\Path was /c/Some/Path.  This broke determination of whether a
repo directory was under the parent directory, which used
process.cwd() which returned the C:\ style paths.  This was fixed in
two ways.  First, on win32 we lowercase the paths and compare and if
that does not work we cygwin-ize them and compare again.  Second, we
no longer have the Git hook shell script provide the current directory
or any other argument, preferring to do all that work in Node.js.  We
do accept values for branch and SHA, but any provided directory is
ignored.

On darwin, the file system can be either case sensitive or
insensitive, with the latter being the default.  Fortunately, it
appears the casing is internally consistent on that platform as we
have not seen an issue on it.

Add both directories to skipping message in handlePushBasedEventOnRepo
to make it more clear what is going on.

Use HookEvent enum type more strictly.

Move expandedTreeUtils test under parallel directory as source.

Update TypeScript config and package scripts.  Add test coverage.
Remove tsfmt.

Fixes #195