### PR TITLE
Change the default Atomist project directory

### DIFF
--- a/lib/sdm/configuration/defaultLocalSoftwareDeliveryMachineConfiguration.ts
+++ b/lib/sdm/configuration/defaultLocalSoftwareDeliveryMachineConfiguration.ts
@@ -44,7 +44,7 @@ import { FileSystemProjectLoader } from "../binding/project/FileSystemProjectLoa
 import { fileSystemProjectPersister } from "../binding/project/fileSystemProjectPersister";
 import { LocalRepoTargets } from "../binding/project/LocalRepoTargets";
 
-const DefaultAtomistRoot = "atomist";
+const DefaultAtomistRoot = "atomist/projects";
 
 /**
  * Defaults for local-SDM configuration

--- a/lib/sdm/configuration/defaultLocalSoftwareDeliveryMachineConfiguration.ts
+++ b/lib/sdm/configuration/defaultLocalSoftwareDeliveryMachineConfiguration.ts
@@ -44,7 +44,7 @@ import { FileSystemProjectLoader } from "../binding/project/FileSystemProjectLoa
 import { fileSystemProjectPersister } from "../binding/project/fileSystemProjectPersister";
 import { LocalRepoTargets } from "../binding/project/LocalRepoTargets";
 
-const DefaultAtomistRoot = "atomist/projects";
+const DefaultAtomistRoot = path.join("atomist", "projects");
 
 /**
  * Defaults for local-SDM configuration


### PR DESCRIPTION
from ~/atomist to ~/atomist/projects
This lets us potentially put other things in ~/atomist (Rod had some ideas to use this)
and also it helps us name the thing. Currently variables holding this value are called
repositoryOwnerParentDirectory which is painful.

The part where it gives the thing a clear name is what I care about. I'm working on the docs and I need to say "the Atomist projects directory" and ~/atomist/projects works for that. As ~/atomist, I don't have a good name for it.

Now, this is not backwards compatible. I could make it so, by checking whether there's already a ~/atomist with subdirectories (but not a projects/ subdirectory). What do you think? worth it?