### PR TITLE
Have post-receive hook script read from stdin

### DIFF
--- a/lib/cli/entry/argsToGitHookInvocation.ts
+++ b/lib/cli/entry/argsToGitHookInvocation.ts
@@ -61,13 +61,18 @@ export async function argsToGitHookInvocation(
     } else {
         if (event === HookEvent.PostReceive) {
             return new Promise<GitHookInvocation>((resolve, reject) => {
-                let input: string;
+                let input: string = "";
                 process.stdin.on("data", chunk => {
                     input += chunk.toString();
                 });
                 process.stdin.on("end", () => {
                     const inputWords = input.trim().split(/\s+/);
-                    // post-receive stdin: oldrev newrev refname
+                    if (inputWords.length < 3) {
+                        const msg = `Git post-receive hook did not receive SHA and branch on standard input`;
+                        logger.error(msg);
+                        reject(new Error(msg));
+                    }
+                    // post-receive stdin: before after refname
                     const sha = inputWords[1];
                     const branch = cleanBranch(inputWords[2]);
                     resolve({ event, baseDir, branch, sha, workspaceId });

--- a/lib/cli/setup/addGitHooks.ts
+++ b/lib/cli/setup/addGitHooks.ts
@@ -130,7 +130,9 @@ function scriptFragments(): { [key in HookEvent]: string } {
         [HookEvent.PostReceive]: `
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-atomist git-hook ${HookEvent.PostReceive}${bg}
+while read before after ref; do
+    atomist git-hook ${HookEvent.PostReceive} "$PWD" "$ref" "$after"${bg}
+done
 `,
         [HookEvent.PostCommit]: `
 atomist git-hook ${HookEvent.PostCommit}${bg}

--- a/test/cli/entry/argsToGitHookInvocation.test.ts
+++ b/test/cli/entry/argsToGitHookInvocation.test.ts
@@ -147,6 +147,17 @@ describe("argsToGitHookInvocation", () => {
             assert.strictEqual(i.workspaceId, tcr.workspaceContext.workspaceId);
         });
 
+        it("should parse git-hook post-receive command line", async () => {
+            const a = ["node", "atomist", "git-hook", HookEvent.PostReceive, "X:\\Men\\Logan\\projects\\o\\r",
+                "other-branch", "074e828a"];
+            const i = await argsToGitHookInvocation(a, tcr);
+            assert(i.event === "post-receive");
+            assert(i.baseDir === repoPath);
+            assert(i.branch === "other-branch");
+            assert(i.sha === "074e828a");
+            assert(i.workspaceId === tcr.workspaceContext.workspaceId);
+        });
+
         it("should parse git-hook command line on win32", async () => {
             repoPath = "L:\\Users\\stan\\atomist\\Own\\the-repo";
             const a = ["node", "atomist", "git-hook", "post-merge", repoPath, "branch", "sha"];
@@ -243,9 +254,10 @@ describe("argsToGitHookInvocation", () => {
 
             let originalProcessCwd: any;
             let originalProcessStdin: any;
+            const baseDir = "C:\\Users\\Stan\\atomist\\Own\\rep";
             before(() => {
                 originalProcessCwd = Object.getOwnPropertyDescriptor(process, "cwd");
-                Object.defineProperty(process, "cwd", { value: () => "C:\\Users\\Stan\\atomist\\Own\\rep\\.git\\" });
+                Object.defineProperty(process, "cwd", { value: () => `${baseDir}\\.git\\` });
                 originalProcessStdin = Object.getOwnPropertyDescriptor(process, "stdin");
                 Object.defineProperty(process, "stdin", {
                     value: {
@@ -268,7 +280,7 @@ describe("argsToGitHookInvocation", () => {
                 const a = ["node", "atomist", "git-hook", HookEvent.PostReceive];
                 const i = await argsToGitHookInvocation(a, tcr);
                 assert(i.event === "post-receive");
-                assert(i.baseDir === "C:\\Users\\Stan\\atomist\\Own\\rep");
+                assert(i.baseDir === baseDir);
                 assert(i.branch === branch);
                 assert(i.sha === sha);
                 assert(i.workspaceId === tcr.workspaceContext.workspaceId);

--- a/test/cli/setup/addGitHooks.test.ts
+++ b/test/cli/setup/addGitHooks.test.ts
@@ -398,7 +398,9 @@ atomist git-hook ${h}
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-atomist git-hook ${h}
+while read before after ref; do
+    atomist git-hook ${h} "$PWD" "$ref" "$after"
+done
 
 ######### Atomist end #########
 `;
@@ -440,7 +442,9 @@ echo ${h}
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-atomist git-hook ${h}
+while read before after ref; do
+    atomist git-hook ${h} "$PWD" "$ref" "$after"
+done
 
 ######### Atomist end #########
 `;
@@ -490,7 +494,9 @@ atomist git-hook ${h} &
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-atomist git-hook ${h} &
+while read before after ref; do
+    atomist git-hook ${h} "$PWD" "$ref" "$after" &
+done
 
 ######### Atomist end #########
 `;
@@ -532,7 +538,9 @@ echo ${h}
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-atomist git-hook ${h} &
+while read before after ref; do
+    atomist git-hook ${h} "$PWD" "$ref" "$after" &
+done
 
 ######### Atomist end #########
 `;
@@ -629,7 +637,9 @@ atomist git-hook ${h} &
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-atomist git-hook ${h} &
+while read before after ref; do
+    atomist git-hook ${h} "$PWD" "$ref" "$after" &
+done
 
 ######### Atomist end #########
 `;
@@ -676,7 +686,9 @@ echo some non-Atomist-y ${h}
 
 ATOMIST_GITHOOK_VERBOSE=true
 export ATOMIST_GITHOOK_VERBOSE
-atomist git-hook ${h} &
+while read before after ref; do
+    atomist git-hook ${h} "$PWD" "$ref" "$after" &
+done
 
 ######### Atomist end #########
 `;


### PR DESCRIPTION
The post-receive Git hook script was not forwarding its standard input
to the `atomist git-hook post-receive` function it was calling.
Rather than fixing this omission, revert back to having the script
read the references from standard input and pass those as command-line
arguments to `atomist git-hook post-receive`.  This is better because
it allows other functionality in the post-receive script, should
people be using it.  The reading by the shell script was improved to
account for the case when multiple heads are pushed, calling `atomist
git-hook post-receive` for each one.

For future reference, the post-receive hook is called when a reference
from a clone of the repo is pushed to the parent repo, something that
happens, for example, when running transforms and autofixes in local
mode.  For each head (branch) pushed, the post-receive hook script
receives one line on standard input with the before SHA, after SHA,
and reference name, in that order and separated by white space.
https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks

Closes #210