### PR TITLE
Correctly populate github secret

### DIFF
--- a/lib/cli/embedded/embeddedMachine.ts
+++ b/lib/cli/embedded/embeddedMachine.ts
@@ -100,7 +100,6 @@ function configurationFor(options: EmbeddedMachineOptions): Configuration {
     cfg.ingesters = [];
     cfg.listeners = [];
 
-    cfg.token = "not.your.token";
     cfg.apiKey = "not.your.apiKey";
 
     cfg.local = {

--- a/lib/cli/invocation/command/support/runCommandOnColocatedAutomationClient.ts
+++ b/lib/cli/invocation/command/support/runCommandOnColocatedAutomationClient.ts
@@ -30,6 +30,7 @@ import * as inquirer from "inquirer";
 import * as _ from "lodash";
 import { CommandHandlerInvocation } from "../../../../common/invocation/CommandHandlerInvocation";
 import { InvocationTarget } from "../../../../common/invocation/InvocationTarget";
+import { credentialsFromEnvironment } from "../../../../sdm/binding/EnvironmentTokenCredentialsResolver";
 import { ExtraParametersMappedParameterResolver } from "../../../../sdm/binding/mapped-parameter/CommandLineMappedParameterResolver";
 import { FromAnyMappedParameterResolver } from "../../../../sdm/binding/mapped-parameter/FromAnyMappedParameterResolver";
 import { MappedParameterResolver } from "../../../../sdm/binding/mapped-parameter/MappedParameterResolver";
@@ -93,7 +94,7 @@ export async function runCommandOnColocatedAutomationClient(connectionConfig: Au
         .map(name => ({ name: convertToUsable(name), value: command[name] }))
         .filter(keep => !!keep.value);
     const args = [
-        { name: "github://user_token?scopes=repo,user:email,read:user", value: null },
+        { name: "github://user_token?scopes=repo,user:email,read:user", value: credentialsFromEnvironment().token },
     ]
         .concat(extraArgs);
     await promptForMissingParameters(hm, args);

--- a/lib/cli/invocation/http/invokeCommandHandlerUsingHttp.ts
+++ b/lib/cli/invocation/http/invokeCommandHandlerUsingHttp.ts
@@ -18,6 +18,7 @@ import { logger } from "@atomist/automation-client";
 import * as assert from "power-assert";
 import { CommandHandlerInvoker } from "../../../common/invocation/CommandHandlerInvocation";
 import { propertiesToArgs } from "../../../common/util/propertiesToArgs";
+import { credentialsFromEnvironment } from "../../../sdm/binding/EnvironmentTokenCredentialsResolver";
 import { AutomationClientConnectionRequest } from "./AutomationClientConnectionRequest";
 import { postToSdm } from "./support/httpInvoker";
 import { newCliCorrelationId } from "./support/newCorrelationId";
@@ -37,7 +38,7 @@ export function invokeCommandHandlerUsingHttp(location: AutomationClientConnecti
                 { name: "slackTeam", value: invocation.workspaceId },
             ]).concat(parameters), // mapped parameters can also be passed in
             secrets: (invocation.secrets || []).concat([
-                { uri: "github://user_token?scopes=repo,user:email,read:user", value: process.env.GITHUB_TOKEN },
+                { uri: "github://user_token?scopes=repo,user:email,read:user", value: credentialsFromEnvironment().token },
             ]),
             correlation_id: invocation.correlationId || await newCliCorrelationId(),
             api_version: "1",

--- a/lib/cli/invocation/http/invokeEventHandlerUsingHttp.ts
+++ b/lib/cli/invocation/http/invokeEventHandlerUsingHttp.ts
@@ -23,6 +23,7 @@ import { replacer } from "@atomist/automation-client/lib/internal/transport/Abst
 import * as stringify from "json-stringify-safe";
 import { EventSender } from "../../../common/invocation/EventHandlerInvocation";
 import { InvocationTarget } from "../../../common/invocation/InvocationTarget";
+import { credentialsFromEnvironment } from "../../../sdm/binding/EnvironmentTokenCredentialsResolver";
 import { AutomationClientConnectionRequest } from "./AutomationClientConnectionRequest";
 import { postToSdm } from "./support/httpInvoker";
 import { newCliCorrelationId } from "./support/newCorrelationId";
@@ -63,10 +64,10 @@ export function invokeEventHandlerUsingHttp(location: AutomationClientConnection
                 correlation_id: target.correlationId || await newCliCorrelationId(),
             },
             secrets: (invocation.secrets || []).concat([
-                { uri: "github://user_token?scopes=repo,user:email,read:user", value: process.env.GITHUB_TOKEN },
-                { uri: "github://org_token", value: process.env.GITHUB_TOKEN },
-                { uri: Secrets.OrgToken, value: process.env.GITHUB_TOKEN },
-                { uri: Secrets.UserToken, value: process.env.GITHUB_TOKEN },
+                { uri: "github://user_token?scopes=repo,user:email,read:user", value: credentialsFromEnvironment().token },
+                { uri: "github://org_token", value: credentialsFromEnvironment().token },
+                { uri: Secrets.OrgToken, value: credentialsFromEnvironment().token },
+                { uri: Secrets.UserToken, value: credentialsFromEnvironment().token },
             ]),
             api_version: "1",
             data: invocation.payload,

--- a/lib/cli/invocation/http/invokeEventHandlerUsingHttp.ts
+++ b/lib/cli/invocation/http/invokeEventHandlerUsingHttp.ts
@@ -55,6 +55,7 @@ export function invokeEventHandlerUsingHttp(location: AutomationClientConnection
                                             target: InvocationTarget): EventSender {
     assert(!!target);
     return async invocation => {
+        const token = credentialsFromEnvironment().token;
         const data = {
             extensions: {
                 operationName: invocation.name,
@@ -64,10 +65,10 @@ export function invokeEventHandlerUsingHttp(location: AutomationClientConnection
                 correlation_id: target.correlationId || await newCliCorrelationId(),
             },
             secrets: (invocation.secrets || []).concat([
-                { uri: "github://user_token?scopes=repo,user:email,read:user", value: credentialsFromEnvironment().token },
-                { uri: "github://org_token", value: credentialsFromEnvironment().token },
-                { uri: Secrets.OrgToken, value: credentialsFromEnvironment().token },
-                { uri: Secrets.UserToken, value: credentialsFromEnvironment().token },
+                { uri: "github://user_token?scopes=repo,user:email,read:user", value: token },
+                { uri: "github://org_token", value: token },
+                { uri: Secrets.OrgToken, value: token },
+                { uri: Secrets.UserToken, value: token },
             ]),
             api_version: "1",
             data: invocation.payload,

--- a/lib/sdm/binding/EnvironmentTokenCredentialsResolver.ts
+++ b/lib/sdm/binding/EnvironmentTokenCredentialsResolver.ts
@@ -19,6 +19,7 @@ import {
     logger,
     Parameters,
     ProjectOperationCredentials,
+    TokenCredentials,
 } from "@atomist/automation-client";
 import { getUserConfig } from "@atomist/automation-client/lib/configuration";
 import {
@@ -47,7 +48,7 @@ export class EnvironmentTokenCredentialsResolver implements CredentialsResolver 
 
 const DefaultGitHubToken = "not.a.real.token";
 
-function credentialsFromEnvironment(): ProjectOperationCredentials {
+export function credentialsFromEnvironment(): TokenCredentials {
     let token;
     try {
         return { token: configurationValue<string>("token") };

--- a/lib/sdm/invocation/invokeCommandHandlerInProcess.ts
+++ b/lib/sdm/invocation/invokeCommandHandlerInProcess.ts
@@ -21,6 +21,7 @@ import {
 } from "@atomist/automation-client";
 import { CommandHandlerInvoker } from "../../common/invocation/CommandHandlerInvocation";
 import { propertiesToArgs } from "../../common/util/propertiesToArgs";
+import { credentialsFromEnvironment } from "../binding/EnvironmentTokenCredentialsResolver";
 
 export type CommandHandlerCallback = (result: Promise<HandlerResult>) => void;
 const DefaultCommandHandlerCallback = () => { /* intentionally left empty */ };
@@ -35,7 +36,7 @@ export function invokeCommandHandlerInProcess(callback: CommandHandlerCallback =
                 { name: "slackTeam", value: invocation.workspaceId },
             ]).concat(parameters), // mapped parameters can also be passed in
             secrets: (invocation.secrets || []).concat([
-                { uri: "github://user_token?scopes=repo,user:email,read:user", value: process.env.GITHUB_TOKEN },
+                { uri: "github://user_token?scopes=repo,user:email,read:user", value: credentialsFromEnvironment().token },
             ]),
             // tslint:disable-next-line:variable-name
             correlation_id: invocation.correlationId,

--- a/lib/sdm/invocation/invokeEventHandlerInProcess.ts
+++ b/lib/sdm/invocation/invokeEventHandlerInProcess.ts
@@ -44,6 +44,7 @@ export function invokeEventHandlerInProcess(workspaceContext: LocalWorkspaceCont
         const team_id = workspaceContext.workspaceId;
         // tslint:disable-next-line:variable-name
         const team_name = workspaceContext.workspaceName;
+        const token = credentialsFromEnvironment().token;
 
         const data = {
             extensions: {
@@ -54,10 +55,10 @@ export function invokeEventHandlerInProcess(workspaceContext: LocalWorkspaceCont
                 correlation_id: correlationId || await newCliCorrelationId(),
             },
             secrets: (invocation.secrets || []).concat([
-                { uri: "github://user_token?scopes=repo,user:email,read:user", value: credentialsFromEnvironment().token },
-                { uri: "github://org_token", value: credentialsFromEnvironment().token },
-                { uri: Secrets.OrgToken, value: credentialsFromEnvironment().token },
-                { uri: Secrets.UserToken, value: credentialsFromEnvironment().token },
+                { uri: "github://user_token?scopes=repo,user:email,read:user", value: token },
+                { uri: "github://org_token", value: token },
+                { uri: Secrets.OrgToken, value: token },
+                { uri: Secrets.UserToken, value: token },
             ]),
             api_version: "1",
             data: invocation.payload,

--- a/lib/sdm/invocation/invokeEventHandlerInProcess.ts
+++ b/lib/sdm/invocation/invokeEventHandlerInProcess.ts
@@ -27,6 +27,7 @@ import * as assert from "power-assert";
 import { newCliCorrelationId } from "../../cli/invocation/http/support/newCorrelationId";
 import { EventSender } from "../../common/invocation/EventHandlerInvocation";
 import { LocalWorkspaceContext } from "../../common/invocation/LocalWorkspaceContext";
+import { credentialsFromEnvironment } from "../binding/EnvironmentTokenCredentialsResolver";
 
 /**
  * Invoke an event handler on the automation client at the given location
@@ -53,10 +54,10 @@ export function invokeEventHandlerInProcess(workspaceContext: LocalWorkspaceCont
                 correlation_id: correlationId || await newCliCorrelationId(),
             },
             secrets: (invocation.secrets || []).concat([
-                { uri: "github://user_token?scopes=repo,user:email,read:user", value: process.env.GITHUB_TOKEN },
-                { uri: "github://org_token", value: process.env.GITHUB_TOKEN },
-                { uri: Secrets.OrgToken, value: process.env.GITHUB_TOKEN },
-                { uri: Secrets.UserToken, value: process.env.GITHUB_TOKEN },
+                { uri: "github://user_token?scopes=repo,user:email,read:user", value: credentialsFromEnvironment().token },
+                { uri: "github://org_token", value: credentialsFromEnvironment().token },
+                { uri: Secrets.OrgToken, value: credentialsFromEnvironment().token },
+                { uri: Secrets.UserToken, value: credentialsFromEnvironment().token },
             ]),
             api_version: "1",
             data: invocation.payload,


### PR DESCRIPTION
This will correctly use the token from the running client or configuration when invoking the command locally.

Fixes #215 