### PR TITLE
Remove the message about channels

### DIFF
--- a/docs/onStartListener.md
+++ b/docs/onStartListener.md
@@ -1,7 +1,0 @@
-
-To narrow your feed to specific channels, use the optional
-`channel` argument as follows:
-
-```bash
-atomist feed --channel=AccountService --channel=BillingService
-```

--- a/lib/cli/invocation/command/addBootstrapCommands.ts
+++ b/lib/cli/invocation/command/addBootstrapCommands.ts
@@ -35,6 +35,7 @@ import { AddLocalMode } from "./transform/addLocalModeTransform";
 /**
  * Add bootstrap commands to generate a new SDM
  * and add local capability to an existing SDM
+ *
  * @param {YargBuilder} yargs
  */
 export function addBootstrapCommands(yargs: YargBuilder) {


### PR DESCRIPTION
I don't know that this channel filtering is used by anyone, so let's remove the concept from the experience. If they want to, they can find this in the README. but really, in local mode, you can only run one feed, so why would you filter it?