### PR TITLE
Fix FileSystemRemoteRepoRef branch implementation

### DIFF
--- a/lib/cli/invocation/http/invokeEventHandlerUsingHttp.ts
+++ b/lib/cli/invocation/http/invokeEventHandlerUsingHttp.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import {
     Secrets,
     Success,
 } from "@atomist/automation-client";
-import { replacer } from "@atomist/automation-client/lib/internal/transport/AbstractRequestProcessor";
+import { replacer } from "@atomist/automation-client/lib/internal/util/string";
 import * as stringify from "json-stringify-safe";
 import { EventSender } from "../../../common/invocation/EventHandlerInvocation";
 import { InvocationTarget } from "../../../common/invocation/InvocationTarget";

--- a/lib/sdm/binding/project/FileSystemRemoteRepoRef.ts
+++ b/lib/sdm/binding/project/FileSystemRemoteRepoRef.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,9 @@ export class FileSystemRemoteRepoRef extends AbstractRemoteRepoRef {
 
     public kind: string = "file";
 
+    public readonly repositoryOwnerParentDirectory: string;
+    public mergePullRequests: boolean;
+
     public static fromDirectory(opts: {
         repositoryOwnerParentDirectory: string,
         mergePullRequests: boolean,
@@ -49,16 +52,10 @@ export class FileSystemRemoteRepoRef extends AbstractRemoteRepoRef {
         sha?: string,
     }): FileSystemRemoteRepoRef {
         const { owner, repo } = parseOwnerAndRepo(opts.repositoryOwnerParentDirectory, opts.baseDir);
-        if (!(!!owner && !!repo)) {
+        if (!owner || !repo) {
             throw new Error(`Cannot parse ${opts.repositoryOwnerParentDirectory}/owner/repo from '${opts.baseDir}'`);
         }
-        return new FileSystemRemoteRepoRef({
-            repositoryOwnerParentDirectory: opts.repositoryOwnerParentDirectory,
-            mergePullRequests: opts.mergePullRequests,
-            branch: opts.branch,
-            sha: opts.sha,
-            owner, repo,
-        });
+        return new FileSystemRemoteRepoRef({ ...opts, owner, repo });
     }
 
     /**
@@ -78,11 +75,11 @@ export class FileSystemRemoteRepoRef extends AbstractRemoteRepoRef {
     }
 
     public createRemote(creds: ProjectOperationCredentials, description: string, visibility: any): Promise<ActionResult<this>> {
-        throw new Error();
+        throw new Error("FileSystemRemoteRepoRef does not implement createRemote");
     }
 
     public deleteRemote(creds: ProjectOperationCredentials): Promise<ActionResult<this>> {
-        throw new Error();
+        throw new Error("FileSystemRemoteRepoRef does not implement deleteRemote");
     }
 
     public async raisePullRequest(creds: ProjectOperationCredentials,
@@ -90,8 +87,8 @@ export class FileSystemRemoteRepoRef extends AbstractRemoteRepoRef {
                                   body: string,
                                   head: string,
                                   base: string): Promise<ActionResult<this>> {
-        if (this.opts.mergePullRequests) {
-            const cwd = path.join(this.opts.repositoryOwnerParentDirectory, this.owner, this.repo);
+        if (this.mergePullRequests) {
+            const cwd = path.join(this.repositoryOwnerParentDirectory, this.owner, this.repo);
 
             // 1. Checkout branch
             await runAndLog(`git checkout ${head}`, { cwd });
@@ -120,37 +117,25 @@ export class FileSystemRemoteRepoRef extends AbstractRemoteRepoRef {
     }
 
     public get url(): string {
-        return `file:/${this.repositoryOwnerParentDirectory}/${this.owner}/${this.repo}`;
+        return `file://${this.repositoryOwnerParentDirectory}/${this.owner}/${this.repo}`;
     }
 
     public get fileSystemLocation(): string {
         return `${this.repositoryOwnerParentDirectory}/${this.owner}/${this.repo}`;
     }
 
-    get repositoryOwnerParentDirectory(): string {
-        return this.opts.repositoryOwnerParentDirectory;
-    }
-
-    get branch(): string {
-        return this.opts.branch;
-    }
-
-    // TODO this should go. It's questionable code in the SDM deploy implementation that hits it
-    set branch(branch: string) {
-        this.opts.branch = branch;
-    }
-
-    constructor(private readonly opts: {
+    constructor(opts: {
         repositoryOwnerParentDirectory: string,
         mergePullRequests: boolean,
         owner: string,
         repo: string,
-        branch: string,
-        sha: string,
+        branch?: string,
+        sha?: string,
     }) {
-        super(null, "http://not.a.real.remote",
-            "http://not.a.real.apiBase",
-            opts.owner, opts.repo, opts.sha);
+        super(undefined, "http://not.a.real.remote", "http://not.a.real.apiBase",
+            opts.owner, opts.repo, opts.sha, undefined, opts.branch);
+        this.repositoryOwnerParentDirectory = opts.repositoryOwnerParentDirectory;
+        this.mergePullRequests = opts.mergePullRequests;
     }
 
 }

--- a/lib/sdm/invocation/invokeEventHandlerInProcess.ts
+++ b/lib/sdm/invocation/invokeEventHandlerInProcess.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Atomist, Inc.
+ * Copyright © 2019 Atomist, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import {
     logger,
     Secrets,
 } from "@atomist/automation-client";
-import { replacer } from "@atomist/automation-client/lib/internal/transport/AbstractRequestProcessor";
+import { replacer } from "@atomist/automation-client/lib/internal/util/string";
 import * as stringify from "json-stringify-safe";
 import * as assert from "power-assert";
 import { newCliCorrelationId } from "../../cli/invocation/http/support/newCorrelationId";

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,16 +48,10 @@
         "@apollographql/graphql-language-service-types": "^2.0.0"
       }
     },
-    "@apollographql/graphql-playground-html": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.6.tgz",
-      "integrity": "sha512-lqK94b+caNtmKFs5oUVXlSpN3sm5IXZ+KfhMxOtr0LR2SqErzkoJilitjDvJ1WbjHlxLI7WtCjRmOLdOGJqtMQ==",
-      "dev": true
-    },
     "@atomist/automation-client": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.3.0.tgz",
-      "integrity": "sha512-w/qwJASDXkYafzFmBVA/3LHycxKxeHjW2ftmaJwIsJt1yolWB3z33bk2ywIctPwW9bihB2arIyHo8WEdCw0xrw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@atomist/automation-client/-/automation-client-1.4.0.tgz",
+      "integrity": "sha512-Gv5UBovPnvDQh5re30iazuuxFh1YB8JBNk2lUC2CPsQYH+La22vJzoT9JbbPy9KlL8pEg6v9tam9QxBrS2Vrow==",
       "dev": true,
       "requires": {
         "@atomist/microgrammar": "^1.2.0",
@@ -93,7 +87,7 @@
         "@types/utf8": "^2.1.6",
         "@types/uuid": "^3.4.4",
         "@types/ws": "^6.0.1",
-        "apollo": "^2.5.0",
+        "apollo": "^2.5.3",
         "apollo-cache-inmemory": "^1.4.3",
         "apollo-client": "^2.4.13",
         "apollo-link": "^1.2.8",
@@ -158,7 +152,7 @@
         "stack-trace": "^0.0.10",
         "stream-spigot": "^3.0.6",
         "strip-ansi": "^5.0.0",
-        "tinyqueue": "^2.0.0",
+        "tinyqueue": "2.0.0",
         "tmp-promise": "^1.0.5",
         "tree-kill": "^1.2.1",
         "typescript": "^3.3.3",
@@ -169,16 +163,6 @@
         "ws": "^6.2.0"
       },
       "dependencies": {
-        "@atomist/microgrammar": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.2.0.tgz",
-          "integrity": "sha512-IW6cU4XjbCTIFAKvyxv8hMkirriWNHvUsSOsKZsmmwf2CxB1TV4POiL+fKAR8NUF/cKQguw1J0MhHlHWzUBK7Q==",
-          "dev": true,
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "stringify-tree": "^1.0.2"
-          }
-        },
         "@types/inquirer": {
           "version": "0.0.43",
           "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.43.tgz",
@@ -247,12 +231,12 @@
       }
     },
     "@atomist/sdm-core": {
-      "version": "1.3.0-master.20190301203019",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.3.0-master.20190301203019.tgz",
-      "integrity": "sha512-nphBrfcyH6ac4aJGQXU/QhheuvIfHkaz3zfQd+oFRqNyXme1wZqBTWTnnd7+knWGRJLD1WHP5GcHWUayn1Z6PQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.4.0.tgz",
+      "integrity": "sha512-NMipb70sW31G9LKZJ2o2co3xetpNHz3PsLieLGmBA48q/hJQSHkAPo+QOU8T+AsYA8SOylyDTKSS88PQ9re38A==",
       "dev": true,
       "requires": {
-        "@kubernetes/client-node": "^0.8.1",
+        "@kubernetes/client-node": "^0.8.2",
         "@octokit/rest": "^16.3.0",
         "@types/proper-lockfile": "^3.0.0",
         "@types/request": "^2.48.1",
@@ -328,18 +312,6 @@
         "@atomist/microgrammar": "^1.2.0",
         "@types/lodash": "^4.14.123",
         "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "@atomist/microgrammar": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.2.0.tgz",
-          "integrity": "sha512-IW6cU4XjbCTIFAKvyxv8hMkirriWNHvUsSOsKZsmmwf2CxB1TV4POiL+fKAR8NUF/cKQguw1J0MhHlHWzUBK7Q==",
-          "dev": true,
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "stringify-tree": "^1.0.2"
-          }
-        }
       }
     },
     "@babel/code-frame": {
@@ -352,12 +324,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-      "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.3.4",
+        "@babel/types": "^7.4.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
@@ -393,12 +365,12 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.4.0"
       }
     },
     "@babel/highlight": {
@@ -413,34 +385,34 @@
       }
     },
     "@babel/parser": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-      "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/types": "^7.2.2"
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-      "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.3.4",
+        "@babel/generator": "^7.4.0",
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.3.4",
-        "@babel/types": "^7.3.4",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/types": "^7.4.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.11"
@@ -458,9 +430,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-      "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -529,9 +501,9 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.8.1.tgz",
-      "integrity": "sha512-Uz8zQ4dCiXXWUihu7gZuVZdDHIVx1nrHmVo46m+xoIbiQHEW2bUHoMn+Vjeo0Sopf2ZSYqMuceM0MpRpGIiEfA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.8.2.tgz",
+      "integrity": "sha512-crS3h59+fOGXQgxVdq3XH81ytY7FV2HnB5z/+lSWD3bi5D5lHKu3PVN2PHCDMNExPy0KthcfqBoIVFVy4CoG3A==",
       "dev": true,
       "requires": {
         "@types/js-yaml": "^3.11.2",
@@ -551,9 +523,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
-          "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
+          "version": "10.14.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+          "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==",
           "dev": true
         }
       }
@@ -570,13 +542,13 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.11",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.11.tgz",
-      "integrity": "sha512-jcdCmaShB7k7Lfr+rGvBeTzcCbprTF690n0dv/cB4PmXESfOx/5P4/scDR75mToht+VxOADI0aXMGQJz3T4uMg==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.12.tgz",
+      "integrity": "sha512-D5/Kph9smL92X1z9WPmxFd9zDruFsCk4/LbfCaBmiO2Vyyt7Y9O6kI1YLsC3B0KC9wymSCTH14IK96rf9AFHfQ==",
       "dev": true,
       "requires": {
         "@oclif/errors": "^1.2.2",
-        "@oclif/parser": "^3.7.2",
+        "@oclif/parser": "^3.7.3",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
       },
@@ -593,9 +565,9 @@
       }
     },
     "@oclif/config": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.0.tgz",
-      "integrity": "sha512-RB6A+N7Dq5DcFOQEhPpB8DdXtMQm2VDgdtgBKUdot815tj4gW7nDmRZBEwU85x4Xhep7Dx3tpaXobA6bFlSOWg==",
+      "version": "1.12.12",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.12.tgz",
+      "integrity": "sha512-0vlX5VYvOfF9QbkCqMyPSzH9GMp6at4Mbqn8CxCskxhKvNZoPD5ocda2ku0zEnoqxGAQ4VfQP7NCqJthuiStfg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -684,9 +656,9 @@
       "dev": true
     },
     "@oclif/parser": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.7.2.tgz",
-      "integrity": "sha512-ssYXztaf9TuOGCJQOYMg62L1Q4y2lB4wZORWng+Iy0ckP2A6IUnQy97V8YjAJkkohYZOu3Mga8LGfQcf+xdIIw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@oclif/parser/-/parser-3.7.3.tgz",
+      "integrity": "sha512-yfYpDzVn9ipo4HZtYLfMtd3j3ArpTQlRbQfy9pNnHFd4VedE2PNYQTRWYYMuu1FxEOoknlMZbzsewVvl41TvKg==",
       "dev": true,
       "requires": {
         "@oclif/linewrap": "^1.0.0",
@@ -793,29 +765,29 @@
       }
     },
     "@oclif/plugin-plugins": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.7.7.tgz",
-      "integrity": "sha512-bKHruaqt3MbQefRJUgsaA1B78J69+26kUA28IhB4GlWO7RpNWEBPIAMeBk/fRB4Tfw2ZuLC7T/zwOFzvY5V1Tw==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.7.8.tgz",
+      "integrity": "sha512-GxLxaf8Lk1RqHVAIBZyA7hmhU7u5oV97i/OsWgFPdjPaT+BmWlWXR8IpmtA8giNo6atR+JpfgDmYndMU75zYUQ==",
       "dev": true,
       "requires": {
         "@oclif/color": "^0.0.0",
-        "@oclif/command": "^1.5.4",
+        "@oclif/command": "^1.5.12",
         "chalk": "^2.4.2",
-        "cli-ux": "^5.0.0",
+        "cli-ux": "^5.2.1",
         "debug": "^4.1.0",
         "fs-extra": "^7.0.1",
         "http-call": "^5.2.2",
-        "load-json-file": "^5.1.0",
-        "npm-run-path": "^2.0.2",
+        "load-json-file": "^5.2.0",
+        "npm-run-path": "^3.0.0",
         "semver": "^5.6.0",
         "tslib": "^1.9.3",
-        "yarn": "^1.13.0"
+        "yarn": "^1.15.0"
       },
       "dependencies": {
         "clean-stack": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
-          "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+          "integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
           "dev": true
         },
         "cli-ux": {
@@ -858,6 +830,21 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
         }
       }
     },
@@ -878,16 +865,6 @@
         "semver": "^5.6.0"
       },
       "dependencies": {
-        "@oclif/config": {
-          "version": "1.12.10",
-          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.10.tgz",
-          "integrity": "sha512-AQYFA72ktXgmrY4hjRtBQRfKLDKXPG4WGSLUgWn0KencNuqnmbiKS6zfKXf1umfZ26zoDOEfCdqZjm3aNZnIaw==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "tslib": "^1.9.3"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -947,70 +924,6 @@
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
-    },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-      "dev": true
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-      "dev": true
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-      "dev": true,
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-      "dev": true
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-      "dev": true
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-      "dev": true
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-      "dev": true
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-      "dev": true
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
@@ -1187,9 +1100,9 @@
       }
     },
     "@types/graphql": {
-      "version": "14.0.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.0.7.tgz",
-      "integrity": "sha512-BoLDjdvLQsXPZLJux3lEZANwGr3Xag56Ngy0U3y8uoRSDdeLcn43H3oBcgZlnd++iOQElBpaRVDHPzEDekyvXQ==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.0.tgz",
+      "integrity": "sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw==",
       "dev": true
     },
     "@types/handlebars": {
@@ -1238,9 +1151,9 @@
       "dev": true
     },
     "@types/js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-UGEe/6RsNAxgWdknhzFZbCxuYc5I7b/YEKlfKbo+76SM8CJzGs7XKCj7zyugXViRbKYpXhSXhCYVQZL5tmDbpQ==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-SGGAhXLHDx+PK4YLNcNGa6goPf9XRWQNAUUbffkwVGGXIxmDKWyGGL4inzq2sPmExu431Ekb9aEMn9BkPqEYFA==",
       "dev": true
     },
     "@types/json-stringify-safe": {
@@ -1257,12 +1170,6 @@
       "version": "4.14.123",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
       "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
-    },
-    "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==",
-      "dev": true
     },
     "@types/marked": {
       "version": "0.6.3",
@@ -1567,9 +1474,9 @@
       "dev": true
     },
     "@types/underscore": {
-      "version": "1.8.13",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.13.tgz",
-      "integrity": "sha512-2YEdDHTYAv3YmSoQofzFnlWYDAAtMtVcQ0lOHoURuCt1aT9OgxhhjRRU1WVAiLchNWM7B3a8/iomxenfr9TwKA==",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.14.tgz",
+      "integrity": "sha512-xbzi6UaATVKupInG3D65/EPQ3qkJCvG2ZAzmlIYt6x93ACOEX2Y0fHW4/e8TF3G7q5KB2l7wTZgzfNjyYDMuZw==",
       "dev": true
     },
     "@types/utf8": {
@@ -1737,28 +1644,28 @@
       }
     },
     "apollo": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.6.1.tgz",
-      "integrity": "sha512-rJT7CVhrnvwZLmfDPshq7BsXzWmqifv0QQ8kSb9MjXWZvRRJ5mkiViS3eiw7gYcQaSEoGh+yppwkqW/0VFMt3Q==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.8.3.tgz",
+      "integrity": "sha512-qYC2T7qtfGhwd+4KaYzUEC9u8Ag9vLY+SKDf0B0wHedVCz3qDXaw3mzu4p8VJCOUUmRPt0eGfbRYw/zsrxQGCw==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "0.3.5",
-        "@oclif/command": "1.5.11",
-        "@oclif/config": "1.12.0",
+        "@oclif/command": "1.5.12",
+        "@oclif/config": "1.12.12",
         "@oclif/errors": "1.2.2",
         "@oclif/plugin-autocomplete": "0.1.0",
         "@oclif/plugin-help": "2.1.6",
         "@oclif/plugin-not-found": "1.2.2",
-        "@oclif/plugin-plugins": "1.7.7",
+        "@oclif/plugin-plugins": "1.7.8",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "0.32.10",
-        "apollo-codegen-flow": "0.32.10",
-        "apollo-codegen-scala": "0.33.6",
-        "apollo-codegen-swift": "0.32.10",
-        "apollo-codegen-typescript": "0.32.11",
-        "apollo-engine-reporting": "0.2.2",
+        "apollo-codegen-core": "0.33.3",
+        "apollo-codegen-flow": "0.33.3",
+        "apollo-codegen-scala": "0.34.3",
+        "apollo-codegen-swift": "0.33.3",
+        "apollo-codegen-typescript": "0.33.3",
         "apollo-env": "0.4.0",
-        "apollo-language-server": "1.5.4",
+        "apollo-graphql": "0.2.0",
+        "apollo-language-server": "1.6.3",
         "chalk": "2.4.2",
         "cli-ux": "4.9.3",
         "env-ci": "3.2.0",
@@ -1783,27 +1690,6 @@
       "requires": {
         "apollo-utilities": "^1.2.1",
         "tslib": "^1.9.3"
-      }
-    },
-    "apollo-cache-control": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.4.1.tgz",
-      "integrity": "sha512-1wGSlIkL1V4S8qmwnWL96F9kq3m4WTeFVUtZ/L2M5BsKkl74YqLa8+UzORJyGE3rfyRbAGa3qg7p21f/DgeezA==",
-      "dev": true,
-      "requires": {
-        "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.4.2"
-      },
-      "dependencies": {
-        "graphql-extensions": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.2.tgz",
-          "integrity": "sha512-a8SD/dlwkg/ujdcf8WnB1RRqgwheSLtY4/Zf5PFZ/nw42ZvD9m9f+tFovUhy1cw25PqQG/MI4xrfDyMy+J7Log==",
-          "dev": true,
-          "requires": {
-            "@apollographql/apollo-tools": "^0.3.0"
-          }
-        }
       }
     },
     "apollo-cache-inmemory": {
@@ -1859,30 +1745,30 @@
       }
     },
     "apollo-codegen-core": {
-      "version": "0.32.10",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.32.10.tgz",
-      "integrity": "sha512-AgC0Yj40PxoL0R3DoyvKGuwxelT3Rsbz1TPcvWJiHqeVBI77Ha01SIp+st9rXlbofHjSxfFC6cJBNrZEu/Cbow==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.33.3.tgz",
+      "integrity": "sha512-tcsFFqhw3vMibCf6SMBOL+yy9UWuM4kZ35FVnUJZcIlTIm0bAUWaK1hu1hAKrugKUBXTk+iwm0BAdWnumsi0zw==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.3.4",
+        "@babel/generator": "7.4.0",
         "@babel/parser": "^7.1.3",
-        "@babel/types": "7.3.4",
+        "@babel/types": "7.4.0",
         "apollo-env": "0.4.0",
-        "apollo-language-server": "1.5.4",
+        "apollo-language-server": "1.6.3",
         "ast-types": "^0.12.0",
         "common-tags": "^1.5.1",
         "recast": "^0.17.0"
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.32.10",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.32.10.tgz",
-      "integrity": "sha512-4PjAKTPyatgI4/GNF972kz5Sw9XX4bnqxj6Sdcc8IqK+TGMSSVVJgCEpEZqMBrmGoMrWsuxP+WqeNqgmmQzlSg==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.3.tgz",
+      "integrity": "sha512-K8x7aQ5FGd/PtQa9dMmkIuXpdoNSfpUzAx7y3/ePnVF5iSf5UoaFc39jBQxJDaK5hc53BpijdPlEGlhA+J/Pow==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.3.4",
-        "@babel/types": "7.3.4",
-        "apollo-codegen-core": "0.32.10",
+        "@babel/generator": "7.4.0",
+        "@babel/types": "7.4.0",
+        "apollo-codegen-core": "0.33.3",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1890,12 +1776,12 @@
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.33.6",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.33.6.tgz",
-      "integrity": "sha512-XBALM0c+E4FjX5eZY3lVHnZ4YREx4cNbaM6U9Lv+wvx8jGq1FLyRuGlLqNYB21sOV7MfKjiPUUGiJniitGt2rA==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.3.tgz",
+      "integrity": "sha512-y3gxk4FRTlEHX7dDI+KUOsL7iYyvbEOlE6oX5r6WNPCuwXusCWMTNTGUbRdQMZwVjrdJvYx85WMSO49pTvlzjg==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.32.10",
+        "apollo-codegen-core": "0.33.3",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1903,12 +1789,12 @@
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.32.10",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.32.10.tgz",
-      "integrity": "sha512-J1WSLQPLjmEFzyZ9QgRRYsKgZZdYBtiQmDqu243QvqBNGYwn4eqUdMZIP1hi+jzEdS/3fdYyiTAFZ41NcH6TCw==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.3.tgz",
+      "integrity": "sha512-va16PtAjO0cYWpTbFj2SNS7ZkslftDJ7W+BAWPWUVw6ynDE2shS/jG280c95SqKOMlgDBl8n++hYid7uhy44bw==",
       "dev": true,
       "requires": {
-        "apollo-codegen-core": "0.32.10",
+        "apollo-codegen-core": "0.33.3",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1916,14 +1802,14 @@
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.32.11",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.32.11.tgz",
-      "integrity": "sha512-HMohdep3Q5aO9/bSROC/L30TRV5maMHFkZQs50MpN4GHG5+tdJqR1YROqa//HDjYzDPczNVaffieKYR2YgOB9A==",
+      "version": "0.33.3",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.33.3.tgz",
+      "integrity": "sha512-2vefpPWC7/upAY/XXAq1GH0FTofHGaJki1zv/992X1Cc4LnSmZ+FXj45jXfoMVIiXUD4KKTb1axHi2efGHvt0Q==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.3.4",
-        "@babel/types": "7.3.4",
-        "apollo-codegen-core": "0.32.10",
+        "@babel/generator": "7.4.0",
+        "@babel/types": "7.4.0",
+        "apollo-codegen-core": "0.33.3",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -1940,29 +1826,6 @@
         "apollo-server-env": "2.2.0"
       }
     },
-    "apollo-engine-reporting": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-0.2.2.tgz",
-      "integrity": "sha512-EiTw/VPLjL7X3EKV21jpr44nRaMv0xGvcbBxc2q6fEaa95tU/QTkwtQv+/3sTaH20+fIY2Rjlo8y6MzKZ3bNdw==",
-      "dev": true,
-      "requires": {
-        "apollo-engine-reporting-protobuf": "0.2.0",
-        "apollo-server-core": "2.3.4",
-        "apollo-server-env": "2.2.0",
-        "async-retry": "^1.2.1",
-        "graphql-extensions": "0.4.3",
-        "lodash": "^4.17.10"
-      }
-    },
-    "apollo-engine-reporting-protobuf": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.2.0.tgz",
-      "integrity": "sha512-qI+GJKN78UMJ9Aq/ORdiM2qymZ5yswem+/VDdVFocq+/e1QqxjnpKjQWISkswci5+WtpJl9SpHBNxG98uHDKkA==",
-      "dev": true,
-      "requires": {
-        "protobufjs": "^6.8.6"
-      }
-    },
     "apollo-env": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.4.0.tgz",
@@ -1974,10 +1837,20 @@
         "sha.js": "^2.4.11"
       }
     },
+    "apollo-graphql": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.2.0.tgz",
+      "integrity": "sha512-wwKynD31Yw1L93IAtnEyhSxBhK4X7NXqkY6wBKWRQ4xph5uJKGgmcQmq3sPieKJT91BGL4AQBv+cwGD3blbLNA==",
+      "dev": true,
+      "requires": {
+        "apollo-env": "0.4.0",
+        "lodash.sortby": "^4.7.0"
+      }
+    },
     "apollo-language-server": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.5.4.tgz",
-      "integrity": "sha512-KPaddk9FJQPE6qenAJ83jM/KcIxugbEPuquWWUPtGOSkSRjiPR2dz47Uuw1z7Gtvxq3RR0c29PgDdx+CHK/QyA==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.6.3.tgz",
+      "integrity": "sha512-NOvib3G3lwkKhKYEiddFPVmCvwExv1IVeaubd8TG5RDYTmYuSsIlyv/cAhZhI4VW1BBtH1gpt0DaI49YQxnJWg==",
       "dev": true,
       "requires": {
         "@apollographql/apollo-tools": "0.3.5",
@@ -1994,7 +1867,7 @@
         "await-to-js": "^2.0.1",
         "core-js": "3.0.0-beta.13",
         "cosmiconfig": "^5.0.6",
-        "dotenv": "^6.1.0",
+        "dotenv": "^7.0.0",
         "glob": "^7.1.3",
         "graphql": "^14.0.2",
         "graphql-tag": "^2.10.1",
@@ -2118,76 +1991,6 @@
         }
       }
     },
-    "apollo-server-core": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.3.4.tgz",
-      "integrity": "sha512-fVnF1V6iVxstRUmtTPmNFgIelRBtEDS4/doLxdOjtNMGrec46KT0LSTU3xaC4Xsv0iY0DlSHtochZsX7ojznBg==",
-      "dev": true,
-      "requires": {
-        "@apollographql/apollo-tools": "^0.3.0",
-        "@apollographql/graphql-playground-html": "^1.6.6",
-        "@types/ws": "^6.0.0",
-        "apollo-cache-control": "0.4.1",
-        "apollo-datasource": "0.2.2",
-        "apollo-engine-reporting": "0.2.2",
-        "apollo-server-caching": "0.2.2",
-        "apollo-server-env": "2.2.0",
-        "apollo-server-errors": "2.2.0",
-        "apollo-server-plugin-base": "0.2.3",
-        "apollo-tracing": "0.4.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "0.4.3",
-        "graphql-subscriptions": "^1.0.0",
-        "graphql-tag": "^2.9.2",
-        "graphql-tools": "^4.0.0",
-        "graphql-upload": "^8.0.2",
-        "lodash": "^4.17.10",
-        "subscriptions-transport-ws": "^0.9.11",
-        "ws": "^6.0.0"
-      },
-      "dependencies": {
-        "apollo-datasource": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.2.2.tgz",
-          "integrity": "sha512-CB9XnZTQHhP9W7IWZH/bR/7/aelMrRdDJ8uoAz59buXbFlb5ExZa/54FGZg7g6q+JQGeFaquMAR1QZb2kfuC9w==",
-          "dev": true,
-          "requires": {
-            "apollo-server-caching": "0.2.2",
-            "apollo-server-env": "2.2.0"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.2.2.tgz",
-          "integrity": "sha512-EYNSR1Vubd14REonCRTJaO/Gr4lkjUTt/45Wp+f1DQtfsAZpHxAtCWafX5fesvq8krdHhSHyEUOTjj2JO8Qi9w==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^5.0.0"
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz",
-          "integrity": "sha512-gV9EZG2tovFtT1cLuCTavnJu2DaKxnXPRNGSTo+SDI6IAk6cdzyW0Gje5N2+3LybI0Wq5KAbW6VLei31S4MWmg==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
-        }
-      }
-    },
     "apollo-server-env": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.2.0.tgz",
@@ -2203,33 +2006,6 @@
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.1.tgz",
       "integrity": "sha512-wY/YE3iJVMYC+WYIf8QODBjIP4jhI+oc7kiYo9mrz7LdYPKAgxr/he+NteGcqn/0Ea9K5/ZFTGJDbEstSMeP8g==",
       "dev": true
-    },
-    "apollo-server-plugin-base": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.2.3.tgz",
-      "integrity": "sha512-NCJUAtr2lnV27pwqQEF2NTyT0yuaJ6qJbBSovtViEf38eXvxTPEXRE2Fg4uELrAVcxKfzQKaCzCScm5iFCcf6A==",
-      "dev": true
-    },
-    "apollo-tracing": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.4.1.tgz",
-      "integrity": "sha512-XQZjhW5gs0EvZityJJuqskeUdJMiuDCt9e5+NqKWlvNaxVhNBUChUpAT4Lkh1RHai2rfFjrW1oCNMZMfC86Sqw==",
-      "dev": true,
-      "requires": {
-        "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.4.2"
-      },
-      "dependencies": {
-        "graphql-extensions": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.2.tgz",
-          "integrity": "sha512-a8SD/dlwkg/ujdcf8WnB1RRqgwheSLtY4/Zf5PFZ/nw42ZvD9m9f+tFovUhy1cw25PqQG/MI4xrfDyMy+J7Log==",
-          "dev": true,
-          "requires": {
-            "@apollographql/apollo-tools": "^0.3.0"
-          }
-        }
-      }
     },
     "apollo-utilities": {
       "version": "1.2.1",
@@ -2397,9 +2173,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.2.tgz",
-      "integrity": "sha512-8c83xDLJM/dLDyXNLiR6afRRm4dPKN6KAnKqytRK3DBJul9lA+atxdQkNDkSVPdTqea5HiRq3lnnOIZ0MBpvdg==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.3.tgz",
+      "integrity": "sha512-wJUcAfrdW+IgDoMGNz5MmcvahKgB7BwIbLupdKVVHxHNYt+HVR2k35swdYNv9aZpF8nvlkjbnkp2rrNwxGckZA==",
       "dev": true
     },
     "async": {
@@ -2427,23 +2203,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
-    },
-    "async-retry": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
-      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
-      "dev": true,
-      "requires": {
-        "retry": "0.12.0"
-      },
-      "dependencies": {
-        "retry": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-          "dev": true
-        }
-      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -2715,9 +2474,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
     "bluebird": {
@@ -2842,15 +2601,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "busboy": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.0.tgz",
-      "integrity": "sha512-e+kzZRAbbvJPLjQz2z+zAyr78BSi9IFeBTyLwF76g78Q2zRt/RZ1NtS3MS17v2yLqYfLz69zHdC+1L4ja8PwqQ==",
-      "dev": true,
-      "requires": {
-        "dicer": "0.3.0"
-      }
     },
     "byline": {
       "version": "5.0.0",
@@ -3075,9 +2825,9 @@
       },
       "dependencies": {
         "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -3218,9 +2968,9 @@
       },
       "dependencies": {
         "clean-stack": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
-          "integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
+          "integrity": "sha512-uQWrpRm+iZZUCAp7ZZJQbd4Za9I3AjR/3YTjmcnAtkauaIm/T5CT6U8zVI6e60T6OANqBFAzuR9/HB3NzuZCRA==",
           "dev": true
         }
       }
@@ -3629,23 +3379,28 @@
       }
     },
     "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
+        "js-yaml": "^3.13.0",
         "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
-    },
-    "crc": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
-      "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms=",
-      "dev": true
     },
     "cron": {
       "version": "1.7.0",
@@ -3879,15 +3634,6 @@
         "kuler": "1.0.x"
       }
     },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "dev": true,
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -3922,9 +3668,9 @@
       }
     },
     "dotenv": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
       "dev": true
     },
     "duplexer3": {
@@ -3943,6 +3689,16 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "duration": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/duration/-/duration-0.2.2.tgz",
+      "integrity": "sha512-06kgtea+bGreF5eKYgI/36A6pLXggY7oR4p1pq4SmdFBn1ReOL5D8RhG64VrqfTTKNucqqtBAwEj8aB88mcqrg==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.46"
       }
     },
     "eastasianwidth": {
@@ -4670,20 +4426,19 @@
       }
     },
     "express-session": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.15.6.tgz",
-      "integrity": "sha512-r0nrHTCYtAMrFwZ0kBzZEXa1vtPVrw0dKvGSrKP4dahwBQ1BJpF2/y1Pp4sCD/0kvxV4zZeclyvfmw0B4RMJQA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.16.1.tgz",
+      "integrity": "sha512-pWvUL8Tl5jUy1MLH7DhgUlpoKeVPUTe+y6WQD9YhcN0C5qAhsh4a8feVjiUXo3TFhIy191YGZ4tewW9edbl2xQ==",
       "dev": true,
       "requires": {
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "crc": "3.4.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "on-headers": "~1.0.1",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
         "parseurl": "~1.3.2",
-        "uid-safe": "~2.1.5",
-        "utils-merge": "1.0.1"
+        "safe-buffer": "5.1.2",
+        "uid-safe": "~2.1.5"
       },
       "dependencies": {
         "debug": {
@@ -4694,6 +4449,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -5038,12 +4799,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
-    },
-    "fs-capacitor": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.1.tgz",
-      "integrity": "sha512-kyV2oaG1/pu9NPosfGACmBym6okgzyg6hEtA5LSUq0dGpGLe278MVfMwVnSHDA/OBcTCHkPNqWL9eIwbPN6dDg==",
-      "dev": true
     },
     "fs-extra": {
       "version": "7.0.1",
@@ -5986,15 +5741,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "graphql-extensions": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.3.tgz",
-      "integrity": "sha512-BEFZ7atqvzMInNTYEUAH5n091K4b5CE9+OZ25XfINc/9dKLR6Uft5DmwniDh/9v9dDCO5FhhIFBr0JmGtHDzeA==",
-      "dev": true,
-      "requires": {
-        "@apollographql/apollo-tools": "^0.3.0"
-      }
-    },
     "graphql-import": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
@@ -6020,15 +5766,6 @@
       "dev": true,
       "requires": {
         "cross-fetch": "2.2.2"
-      }
-    },
-    "graphql-subscriptions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.0.0.tgz",
-      "integrity": "sha512-+ytmryoHF1LVf58NKEaNPRUzYyXplm120ntxfPcgOBC7TnK7Tv/4VRHeh4FAR9iL+O1bqhZs4nkibxQ+OA5cDQ==",
-      "dev": true,
-      "requires": {
-        "iterall": "^1.2.1"
       }
     },
     "graphql-tag": {
@@ -6095,39 +5832,6 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
-      }
-    },
-    "graphql-upload": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.4.tgz",
-      "integrity": "sha512-jsTfVYXJ5mU6BXiiJ20CUCAcf41ICCQJ2ltwQFUuaFKiY4JhlG99uZZp5S3hbpQ/oA1kS7hz4pRtsnxPCa7Yfg==",
-      "dev": true,
-      "requires": {
-        "busboy": "^0.3.0",
-        "fs-capacitor": "^2.0.0",
-        "http-errors": "^1.7.1",
-        "object-path": "^0.11.4"
-      },
-      "dependencies": {
-        "http-errors": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-          "dev": true,
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
-            "toidentifier": "1.0.0"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true
-        }
       }
     },
     "growl": {
@@ -6397,9 +6101,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
       "dev": true
     },
     "homedir-polyfill": {
@@ -7418,15 +7122,24 @@
       }
     },
     "load-json-file": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.2.0.tgz",
-      "integrity": "sha512-HvjIlM2Y/RDHk1X6i4sGgaMTrAsnNrgQCJtuf5PEhbOV6MCJuMVZLMdlJRE0JGLMkF7b6O5zs9LcDxKIUt9CbQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.1.15",
         "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
+        "pify": "^4.0.1",
+        "strip-bom": "^3.0.0",
+        "type-fest": "^0.3.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "locate-path": {
@@ -7473,6 +7186,12 @@
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "lodash.template": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
@@ -7504,14 +7223,30 @@
       "dev": true
     },
     "log": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/log/-/log-3.2.0.tgz",
-      "integrity": "sha512-JDRv2YAFsBXRiYdgqbFyHgNtvr+ezLLjxG83imXJblxerzvPNWbF2DCQfKu/5M1DU9bcmDl/WMSc87RRe6y1NA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/log/-/log-6.0.0.tgz",
+      "integrity": "sha512-sxChESNYJ/EcQv8C7xpmxhtTOngoXuMEqGDAkhXBEmt3MAzM3SM/TmIBOqnMEVdrOv1+VgZoYbo6U2GemQiU4g==",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "event-emitter": "^0.3.5"
+        "d": "^1.0.0",
+        "duration": "^0.2.2",
+        "es5-ext": "^0.10.49",
+        "event-emitter": "^0.3.5",
+        "sprintf-kit": "^2.0.0",
+        "type": "^1.0.1"
+      },
+      "dependencies": {
+        "es5-ext": {
+          "version": "0.10.49",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
+          "integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
+          "dev": true,
+          "requires": {
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.1",
+            "next-tick": "^1.0.0"
+          }
+        }
       }
     },
     "log-symbols": {
@@ -7633,12 +7368,6 @@
           "dev": true
         }
       }
-    },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
     },
     "lower-case": {
       "version": "1.1.4",
@@ -8062,9 +7791,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
-      "integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
       "dev": true,
       "optional": true
     },
@@ -8088,9 +7817,9 @@
       }
     },
     "natural-orderby": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.1.tgz",
-      "integrity": "sha512-TbzN58QCKHD9cfKO1QaAoLC/KiVfEcCHl/5RIlh7A7pfG6xFJVxHEZIqt1LmwEh0N4dY8y/7QYgwWpDcu/PLOA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
+      "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q==",
       "dev": true
     },
     "ndarray": {
@@ -11886,12 +11615,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
       "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
     },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -12140,9 +11863,9 @@
       }
     },
     "p-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
-      "integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "dev": true
     },
     "p-timeout": {
@@ -12668,35 +12391,6 @@
         "retry": "^0.10.0"
       }
     },
-    "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-      "dev": true,
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.14.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
-          "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA==",
-          "dev": true
-        }
-      }
-    },
     "protocols": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
@@ -12851,12 +12545,12 @@
       }
     },
     "recast": {
-      "version": "0.17.3",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.3.tgz",
-      "integrity": "sha512-NwQguXPwHqaVb6M7tsY11+8RDoAKHGRdymPGDxHJrsxOlNADQh0b08uz/MgYp1R1wmHuSBK4A4I5Oq+cE1J40g==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.5.tgz",
+      "integrity": "sha512-K+DgfAMIyEjNKjaFSWgg9TTu7wFgU/4KTyw4E9vl6M5QPDuUYbyt49Yzb0EIDbZks+6lXk/UZ9eTuE4jlLyf2A==",
       "dev": true,
       "requires": {
-        "ast-types": "0.12.2",
+        "ast-types": "0.12.3",
         "esprima": "~4.0.0",
         "private": "^0.1.8",
         "source-map": "~0.6.1"
@@ -13530,6 +13224,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
+    "sprintf-kit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sprintf-kit/-/sprintf-kit-2.0.0.tgz",
+      "integrity": "sha512-/0d2YTn8ZFVpIPAU230S9ZLF8WDkSSRWvh/UOLM7zzvkCchum1TtouRgyV8OfgOaYilSGU4lSSqzwBXJVlAwUw==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.46"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -13670,12 +13373,6 @@
           }
         }
       }
-    },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
-      "dev": true
     },
     "strict-uri-encode": {
       "version": "1.1.0",
@@ -14019,12 +13716,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "dev": true
-    },
     "topo": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
@@ -14094,9 +13785,9 @@
       "dev": true
     },
     "ts-invariant": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.2.tgz",
-      "integrity": "sha512-QsY8BCaRnHiB5T6iE4DPlJMAKEG3gzMiUco9FEt1jUXQf0XP6zi0idT0i0rMTu8A326JqNSDsmlkA9dRSh1TRg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
+      "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.3"
@@ -14185,6 +13876,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -14193,6 +13890,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",
@@ -14727,9 +14430,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -14940,9 +14643,9 @@
       }
     },
     "yarn": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.13.0.tgz",
-      "integrity": "sha512-Unfw2eefv8imt4ZMPhvFVP44WCz38huDxkHs+Yqrx4wBTK75Tr0mh3V4rh+2Nw5iQq0rcM/VafotCZo9qTb5DA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.15.2.tgz",
+      "integrity": "sha512-DhqaGe2FcYKduO42d2hByXk7y8k2k42H3uzYdWBMTvcNcgWKx7xCkJWsVAQikXvaEQN2GyJNrz8CboqUmaBRrw==",
       "dev": true
     },
     "yn": {
@@ -14952,9 +14655,9 @@
       "dev": true
     },
     "zen-observable": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.13.tgz",
-      "integrity": "sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
+      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==",
       "dev": true
     },
     "zen-observable-ts": {

--- a/package.json
+++ b/package.json
@@ -69,17 +69,17 @@
     "yargs": "^13.2.2"
   },
   "peerDependencies": {
-    "@atomist/automation-client": ">=1.3.0",
+    "@atomist/automation-client": ">=1.4.0",
     "@atomist/microgrammar": ">=1.2.0",
     "@atomist/sdm": ">=1.3.0",
-    "@atomist/sdm-core": ">=1.3.0",
+    "@atomist/sdm-core": ">=1.4.0",
     "@atomist/slack-messages": ">=1.1.0"
   },
   "devDependencies": {
-    "@atomist/automation-client": "^1.3.0",
+    "@atomist/automation-client": "^1.4.0",
     "@atomist/microgrammar": "^1.2.0",
     "@atomist/sdm": "^1.3.0",
-    "@atomist/sdm-core": "1.3.0-master.20190301203019",
+    "@atomist/sdm-core": "^1.4.0",
     "@atomist/slack-messages": "^1.1.0",
     "@types/mocha": "^5.2.6",
     "@types/power-assert": "^1.5.0",


### PR DESCRIPTION
Do not override branch property implementation with get/set that
requires a fully instantiated this but is possible to call from the
super constructor.

The replacer function moved in automation-client.

Closes #252