### PR TITLE
Remove excess slash from directory

### DIFF
--- a/lib/cli/invocation/command/addBootstrapCommands.ts
+++ b/lib/cli/invocation/command/addBootstrapCommands.ts
@@ -157,7 +157,7 @@ atomist start`);
 }
 
 function removeUrlScheme(url: string): string {
-    return url.replace(/^.*:\//, "");
+    return url.replace(/^.*:\/\//, "");
 }
 
 async function doAfterSpringSdmCreation() {


### PR DESCRIPTION
Currently it is printing:
```
To run your new SDM:
cd //Users/jessitron/code/atomist/examples-sdm;
atomist start
```

It needs one fewer slash in front of that directory.